### PR TITLE
Fix SOCKET redefinition in mrpd.h

### DIFF
--- a/daemons/mrpd/mrpd.h
+++ b/daemons/mrpd/mrpd.h
@@ -47,7 +47,9 @@ size_t mrpd_send(SOCKET sockfd, const void *buf, size_t len, int flags);
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#ifndef SOCKET
 typedef int SOCKET;
+#endif
 typedef int HTIMER;
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR   -1


### PR DESCRIPTION
## Summary
- guard `SOCKET` typedef in `mrpd.h` with `#ifndef SOCKET`

## Testing
- `make all` *(fails: multiple definition of `gPtpTD`)*

------
https://chatgpt.com/codex/tasks/task_e_68527912405c83228f4a566240faa667