### PR TITLE
Fix overflow warning in maap log

### DIFF
--- a/daemons/maap/linux/src/maap_log_linux.c
+++ b/daemons/maap/linux/src/maap_log_linux.c
@@ -285,10 +285,12 @@ void maapLogFn(
 		}
 
 		// using sprintf and puts allows using static buffers rather than heap.
-		if (MAAP_LOG_EXTRA_NEWLINE)
-			/* int32_t full_msg_len = */ sprintf(full_msg, "[%s%s%s%s %s %s%s] %s: %s\n", time_msg, timestamp_msg, proc_msg, thread_msg, company, component, file_msg, tag, msg);
-		else
-			/* int32_t full_msg_len = */ sprintf(full_msg, "[%s%s%s%s %s %s%s] %s: %s", time_msg, timestamp_msg, proc_msg, thread_msg, company, component, file_msg, tag, msg);
+               int32_t full_msg_len;
+               if (MAAP_LOG_EXTRA_NEWLINE)
+                       full_msg_len = snprintf(full_msg, LOG_FULL_MSG_LEN, "[%s%s%s%s %s %s%s] %s: %s\n", time_msg, timestamp_msg, proc_msg, thread_msg, company, component, file_msg, tag, msg);
+               else
+                       full_msg_len = snprintf(full_msg, LOG_FULL_MSG_LEN, "[%s%s%s%s %s %s%s] %s: %s", time_msg, timestamp_msg, proc_msg, thread_msg, company, component, file_msg, tag, msg);
+               (void)full_msg_len;
 
 		if (!MAAP_LOG_FROM_THREAD && !MAAP_LOG_PULL_MODE) {
 			fputs(full_msg, MAAP_LOG_OUTPUT_FD);


### PR DESCRIPTION
## Summary
- use `snprintf` with buffer size when formatting MAAP log messages
- store the resulting length to keep the `full_msg_len` reference

## Testing
- `make maap`
- `make all` *(fails: multiple definition of `gPtpTD`)*

------
https://chatgpt.com/codex/tasks/task_e_68527a3fb37883229d7b0fab495f2aa6