### PR TITLE
Increase MAAP log buffer

### DIFF
--- a/daemons/maap/common/maap_log.h
+++ b/daemons/maap/common/maap_log.h
@@ -85,7 +85,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LOG_MSG_LEN 1024
 
 // The length of the full message
-#define LOG_FULL_MSG_LEN 1024
+#define LOG_FULL_MSG_LEN 2048
 
 #ifndef TRUE
 #define TRUE  1


### PR DESCRIPTION
## Summary
- extend `LOG_FULL_MSG_LEN` to 2048 characters
- rebuild the project to verify no `-Wformat-truncation` warnings occur

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_68528167427083229152a026ab45719b