### PR TITLE
Fix SOCKET typedef in mrpd.h

### DIFF
--- a/daemons/mrpd/mrpd.h
+++ b/daemons/mrpd/mrpd.h
@@ -47,7 +47,9 @@ size_t mrpd_send(SOCKET sockfd, const void *buf, size_t len, int flags);
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#ifndef SOCKET
 typedef int SOCKET;
+#endif
 typedef int HTIMER;
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR   -1


### PR DESCRIPTION
## Summary
- only define `SOCKET` on Linux if it isn't already defined

## Testing
- `cmake .. -G "Unix Makefiles"`
- `make`
- `ctest --output-on-failure` *(fails: CppUTestTests.OutOfMemoryTestsForOperatorNew)*

------
https://chatgpt.com/codex/tasks/task_e_6852a5602c1c8322ac49702a463e07bd