### PR TITLE
Fix format-truncation warnings

### DIFF
--- a/daemons/mrpd/mmrp.c
+++ b/daemons/mrpd/mmrp.c
@@ -1428,23 +1428,23 @@ int mmrp_send_notifications(struct mmrp_attribute *attrib, int notify)
 	memset(msgbuf, 0, MAX_MRPD_CMDSZ);
 
 	if (MMRP_SVCREQ_TYPE == attrib->type) {
-		sprintf(variant, "S=%d", attrib->attribute.svcreq);
+               snprintf(variant, 128, "S=%d", attrib->attribute.svcreq);
 	} else {
-		sprintf(variant, "M=%02x%02x%02x%02x%02x%02x",
-			attrib->attribute.macaddr[0],
-			attrib->attribute.macaddr[1],
-			attrib->attribute.macaddr[2],
-			attrib->attribute.macaddr[3],
-			attrib->attribute.macaddr[4],
-			attrib->attribute.macaddr[5]);
+               snprintf(variant, 128, "M=%02x%02x%02x%02x%02x%02x",
+                       attrib->attribute.macaddr[0],
+                       attrib->attribute.macaddr[1],
+                       attrib->attribute.macaddr[2],
+                       attrib->attribute.macaddr[3],
+                       attrib->attribute.macaddr[4],
+                       attrib->attribute.macaddr[5]);
 	}
 
-	sprintf(regsrc, "R=%02x%02x%02x%02x%02x%02x",
-		attrib->registrar.macaddr[0],
-		attrib->registrar.macaddr[1],
-		attrib->registrar.macaddr[2],
-		attrib->registrar.macaddr[3],
-		attrib->registrar.macaddr[4], attrib->registrar.macaddr[5]);
+       snprintf(regsrc, 128, "R=%02x%02x%02x%02x%02x%02x",
+               attrib->registrar.macaddr[0],
+               attrib->registrar.macaddr[1],
+               attrib->registrar.macaddr[2],
+               attrib->registrar.macaddr[3],
+               attrib->registrar.macaddr[4], attrib->registrar.macaddr[5]);
 
 	mrp_decode_state(&attrib->registrar, &attrib->applicant,
 				 mrp_state, sizeof(mrp_state));
@@ -1508,43 +1508,45 @@ int mmrp_dumptable(struct sockaddr_in *client)
 	attrib = MMRP_db->attrib_list;
 
 	if (attrib == NULL) {
-		sprintf(msgbuf, "MMRP:Empty\n");
+               snprintf(msgbuf, MAX_MRPD_CMDSZ, "MMRP:Empty\n");
 	}
 
 	while (NULL != attrib) {
 		if (MMRP_SVCREQ_TYPE == attrib->type) {
-			sprintf(variant, "S=%d", attrib->attribute.svcreq);
+                       snprintf(variant, 128, "S=%d", attrib->attribute.svcreq);
 		} else {
-			sprintf(variant, "M=%02x%02x%02x%02x%02x%02x",
-				attrib->attribute.macaddr[0],
-				attrib->attribute.macaddr[1],
-				attrib->attribute.macaddr[2],
-				attrib->attribute.macaddr[3],
-				attrib->attribute.macaddr[4],
-				attrib->attribute.macaddr[5]);
+                       snprintf(variant, 128, "M=%02x%02x%02x%02x%02x%02x",
+                               attrib->attribute.macaddr[0],
+                               attrib->attribute.macaddr[1],
+                               attrib->attribute.macaddr[2],
+                               attrib->attribute.macaddr[3],
+                               attrib->attribute.macaddr[4],
+                               attrib->attribute.macaddr[5]);
 		}
-		sprintf(regsrc, "R=%02x%02x%02x%02x%02x%02x",
-			attrib->registrar.macaddr[0],
-			attrib->registrar.macaddr[1],
-			attrib->registrar.macaddr[2],
-			attrib->registrar.macaddr[3],
-			attrib->registrar.macaddr[4],
-			attrib->registrar.macaddr[5]);
+               snprintf(regsrc, 128, "R=%02x%02x%02x%02x%02x%02x",
+                       attrib->registrar.macaddr[0],
+                       attrib->registrar.macaddr[1],
+                       attrib->registrar.macaddr[2],
+                       attrib->registrar.macaddr[3],
+                       attrib->registrar.macaddr[4],
+                       attrib->registrar.macaddr[5]);
 		switch (attrib->registrar.mrp_state) {
 		case MRP_IN_STATE:
-			sprintf(stage, "MIN %s %s\n", variant, regsrc);
+                       snprintf(stage, 128, "MIN %s %s\n", variant, regsrc);
 			break;
 		case MRP_LV_STATE:
-			sprintf(stage, "MLV %s %s\n", variant, regsrc);
+                       snprintf(stage, 128, "MLV %s %s\n", variant, regsrc);
 			break;
 		case MRP_MT_STATE:
-			sprintf(stage, "MMT %s %s\n", variant, regsrc);
+                       snprintf(stage, 128, "MMT %s %s\n", variant, regsrc);
 			break;
 		default:
 			break;
 		}
-		sprintf(msgbuf_wrptr, "%s", stage);
-		msgbuf_wrptr += strnlen(stage, 128);
+               snprintf(msgbuf_wrptr,
+                        MAX_MRPD_CMDSZ - (msgbuf_wrptr - msgbuf),
+                        "%s", stage);
+               msgbuf_wrptr += strnlen(stage, 128);
 		attrib = attrib->next;
 	}
 
@@ -1615,7 +1617,7 @@ int mmrp_recv_cmd(char *buf, int buflen, struct sockaddr_in *client)
 {
 	int rc;
 	int err_index;
-	char respbuf[12];
+       char respbuf[64];
 	int mrp_event;
 	uint8_t svcreq_param;
 	uint8_t macvec_param[6];

--- a/daemons/mrpd/mrpd.c
+++ b/daemons/mrpd/mrpd.c
@@ -258,8 +258,7 @@ mrpd_send_ctl_msg(struct sockaddr_in *client_addr, char *notify_data,
 
 int process_ctl_msg(char *buf, int buflen, struct sockaddr_in *client)
 {
-
-	char respbuf[8];
+        char respbuf[64];
 	/*
 	 * Inbound/output commands from/to a client:
 	 *

--- a/daemons/mrpd/mvrp.c
+++ b/daemons/mrpd/mvrp.c
@@ -1033,14 +1033,14 @@ int mvrp_send_notifications(struct mvrp_attribute *attrib, int notify)
 
 	memset(msgbuf, 0, MAX_MRPD_CMDSZ);
 
-	sprintf(variant, "%04x", attrib->attribute);
+       snprintf(variant, 128, "%04x", attrib->attribute);
 
-	sprintf(regsrc, "R=%02x%02x%02x%02x%02x%02x",
-		attrib->registrar.macaddr[0],
-		attrib->registrar.macaddr[1],
-		attrib->registrar.macaddr[2],
-		attrib->registrar.macaddr[3],
-		attrib->registrar.macaddr[4], attrib->registrar.macaddr[5]);
+       snprintf(regsrc, 128, "R=%02x%02x%02x%02x%02x%02x",
+               attrib->registrar.macaddr[0],
+               attrib->registrar.macaddr[1],
+               attrib->registrar.macaddr[2],
+               attrib->registrar.macaddr[3],
+               attrib->registrar.macaddr[4], attrib->registrar.macaddr[5]);
 
 	mrp_decode_state(&attrib->registrar, &attrib->applicant,
 				 mrp_state, sizeof(mrp_state));
@@ -1105,25 +1105,27 @@ int mvrp_dumptable(struct sockaddr_in *client)
 
 	attrib = MVRP_db->attrib_list;
 	if (attrib == NULL) {
-		sprintf(msgbuf, "MVRP:Empty\n");
+               snprintf(msgbuf, MAX_MRPD_CMDSZ, "MVRP:Empty\n");
 	}
 
 	while (NULL != attrib) {
-		sprintf(variant, "V:I=%04x", attrib->attribute);
+               snprintf(variant, 128, "V:I=%04x", attrib->attribute);
 
 		mrp_decode_state(&attrib->registrar, &attrib->applicant,
 				 mrp_state, sizeof(mrp_state));
 
-		sprintf(regsrc, "R=%02x%02x%02x%02x%02x%02x %s",
-			attrib->registrar.macaddr[0],
-			attrib->registrar.macaddr[1],
-			attrib->registrar.macaddr[2],
-			attrib->registrar.macaddr[3],
-			attrib->registrar.macaddr[4],
-			attrib->registrar.macaddr[5], mrp_state);
+               snprintf(regsrc, 128, "R=%02x%02x%02x%02x%02x%02x %s",
+                       attrib->registrar.macaddr[0],
+                       attrib->registrar.macaddr[1],
+                       attrib->registrar.macaddr[2],
+                       attrib->registrar.macaddr[3],
+                       attrib->registrar.macaddr[4],
+                       attrib->registrar.macaddr[5], mrp_state);
 
-		sprintf(stage, "%s %s\n", variant, regsrc);
-		sprintf(msgbuf_wrptr, "%s", stage);
+               snprintf(stage, 128, "%s %s\n", variant, regsrc);
+               snprintf(msgbuf_wrptr,
+                        MAX_MRPD_CMDSZ - (msgbuf_wrptr - msgbuf),
+                        "%s", stage);
 		msgbuf_wrptr += strnlen(stage, 128);
 		attrib = attrib->next;
 	}
@@ -1173,7 +1175,7 @@ int mvrp_recv_cmd(char *buf, int buflen, struct sockaddr_in *client)
 {
 	int rc;
 	int mrp_event;
-	char respbuf[12];
+       char respbuf[64];
 	uint16_t vid_param;
 	int err_index;
 


### PR DESCRIPTION
## Summary
- use larger respbuf arrays in mrpd, mvrp and mmrp
- replace sprintf with snprintf where possible
- ensure formatted strings won't exceed buffer sizes

## Testing
- `make` in `daemons/mrpd`
- `cmake .. && make -j2` then `ctest --output-on-failure` *(1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_6852b87d43488322947dc8dd938d6ad6