### PR TITLE
Fix thread stack size macro and static PTP data

### DIFF
--- a/.github/workflows/OpenAvnu_Build.yml
+++ b/.github/workflows/OpenAvnu_Build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - '**'
   pull_request:
+    branches:
       - '**'
   workflow_dispatch:
 

--- a/.github/workflows/travis_sh.yml
+++ b/.github/workflows/travis_sh.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run legacy make avdecc
         run: |
-          make avdecc
+          make avtp_avdecc
         continue-on-error: true
 
       - name: Update to latest CppUTest

--- a/lib/avtp_pipeline/platform/Linux/openavb_grandmaster_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_grandmaster_osal.c
@@ -51,7 +51,7 @@ static pthread_mutex_t gOSALGrandmasterInitMutex = PTHREAD_MUTEX_INITIALIZER;
 static bool bInitialized = FALSE;
 static int gShmFd = -1;
 static char *gMmap = NULL;
-gPtpTimeData gPtpTD;
+static gPtpTimeData gPtpTD;
 
 static bool x_grandmasterInit(void) {
 	AVB_TRACE_ENTRY(AVB_TRACE_GRANDMASTER);

--- a/lib/avtp_pipeline/platform/Linux/openavb_tasks.h
+++ b/lib/avtp_pipeline/platform/Linux/openavb_tasks.h
@@ -34,12 +34,14 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include <limits.h>
 
-#if !defined(PTHREAD_STACK_MIN)
-#error "PTHREAD_STACK_MIN variable not defined"
-#elif (PTHREAD_STACK_MIN > 65536)
-#define THREAD_STACK_SIZE							PTHREAD_STACK_MIN
+#if defined(PTHREAD_STACK_MIN) && !defined(__USE_DYNAMIC_STACK_SIZE)
+#  if PTHREAD_STACK_MIN > 65536
+#    define THREAD_STACK_SIZE PTHREAD_STACK_MIN
+#  else
+#    define THREAD_STACK_SIZE 65536
+#  endif
 #else
-#define THREAD_STACK_SIZE							65536
+#  define THREAD_STACK_SIZE 65536
 #endif
 
 ///////////////////////////

--- a/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
+++ b/lib/avtp_pipeline/platform/Linux/openavb_time_osal.c
@@ -51,7 +51,7 @@ static pthread_mutex_t gOSALTimeInitMutex = PTHREAD_MUTEX_INITIALIZER;
 static bool bInitialized = FALSE;
 static int gPtpShmFd = -1;
 static char *gPtpMmap = NULL;
-gPtpTimeData gPtpTD;
+static gPtpTimeData gPtpTD;
 
 static bool x_timeInit(void) {
 	AVB_TRACE_ENTRY(AVB_TRACE_TIME);


### PR DESCRIPTION
## Summary
- allow build when `PTHREAD_STACK_MIN` isn't constant
- avoid duplicate `gPtpTD` symbols by making them file-local

## Testing
- `make avtp_pipeline`
- `make avtp_avdecc`


------
https://chatgpt.com/codex/tasks/task_e_6852bd6e3e6c83228f052900a27e80ab