### PR TITLE
Fix Windows typo

### DIFF
--- a/daemons/mrpd/que.h
+++ b/daemons/mrpd/que.h
@@ -32,7 +32,7 @@
 ******************************************************************************/
 
 /*
- * Windwos specific - queue messages in a thread safe way between threads.
+ * Windows specific - queue messages in a thread safe way between threads.
  */
 
 #ifndef _QUE_H_


### PR DESCRIPTION
## Summary
- fix a typo in the mrpd queue header

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856aaeaf8708322aca63d5699fe3ea5