### PR TITLE
Add Windows OSAL implementations

### DIFF
--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal.c
@@ -1,0 +1,124 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+Attributions: The inih library portion of the source code is licensed from 
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
+Complete license and copyright information can be found at 
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+#include "openavb_platform.h"
+#include "openavb_trace.h"
+#include "openavb_endpoint.h"
+#include "openavb_endpoint_cfg.h"
+#include "openavb_rawsock.h"
+
+#define	AVB_LOG_COMPONENT	"Endpoint"
+//#define AVB_LOG_LEVEL AVB_LOG_LEVEL_DEBUG
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+// the following are from openavb_endpoint.c
+extern openavb_endpoint_cfg_t 	x_cfg;
+extern bool endpointRunning;
+static HANDLE endpointServerHandle;
+static DWORD WINAPI endpointServerThread(LPVOID arg);
+
+
+bool startEndpoint(int mode, int ifindex, const char* ifname, unsigned mtu, unsigned link_kbit, unsigned nsr_kbit)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+	LOG_EAVB_CORE_VERSION();
+
+
+
+	// Set endpoint configuration
+	memset(&x_cfg, 0, sizeof(openavb_endpoint_cfg_t));
+	x_cfg.fqtss_mode = mode;
+	x_cfg.ifindex = ifindex;
+	x_cfg.mtu = mtu;
+
+	x_cfg.link_kbit = link_kbit;
+	x_cfg.nsr_kbit = nsr_kbit;
+
+	openavbReadConfig(DEFAULT_INI_FILE, DEFAULT_SAVE_INI_FILE, &x_cfg);
+
+	if_info_t ifinfo;
+	if (ifname && openavbCheckInterface(ifname, &ifinfo)) {
+		strncpy(x_cfg.ifname, ifname, sizeof(x_cfg.ifname));
+		memcpy(x_cfg.ifmac, &ifinfo.mac, ETH_ALEN);
+		x_cfg.ifindex = ifinfo.index;
+		x_cfg.mtu = ifinfo.mtu;
+	}
+
+        endpointRunning = TRUE;
+        endpointServerHandle = CreateThread(NULL, 0, endpointServerThread, NULL, 0, NULL);
+        if (!endpointServerHandle) {
+                AVB_LOGF_ERROR("Failed to start endpoint thread: %lu", GetLastError());
+                goto error;
+        }
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+	return true;
+
+error:
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+	return false;
+}
+
+void stopEndpoint()
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+
+        endpointRunning = FALSE;
+        WaitForSingleObject(endpointServerHandle, INFINITE);
+        CloseHandle(endpointServerHandle);
+
+	openavbUnconfigure(&x_cfg);
+
+	AVB_LOG_INFO("Shutting down");
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+}
+
+static DWORD WINAPI endpointServerThread(LPVOID arg)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+
+	while (endpointRunning) {
+		int err = avbEndpointLoop();
+		if (err) {
+			AVB_LOG_ERROR("Make sure that mrpd daemon is started.");
+			SLEEP(1);
+		}
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+        return 0;
+}

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal.h
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal.h
@@ -1,0 +1,61 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+Attributions: The inih library portion of the source code is licensed from 
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt. 
+Complete license and copyright information can be found at 
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#ifndef OSAL_ENDPOINT_H
+#define OSAL_ENDPOINT_H
+
+// should only be included from openavb_endpoint.h
+
+#include <winsock2.h>
+#include <windows.h>
+
+typedef struct {
+	openavbEndpointMsgType_t	type;
+	AVBStreamID_t 			streamID;
+	union {
+		// Client messages
+		openavbEndpointParams_TalkerRegister_t 		talkerRegister;
+		openavbEndpointParams_ListenerAttach_t		listenerAttach;
+		openavbEndpointParams_ClientStop_t			clientStop;
+		openavbEndpointParams_VersionRequest_t		versionRequest;
+
+		// Server messages
+		openavbEndpointParams_TalkerCallback_t		talkerCallback;
+		openavbEndpointParams_ListenerCallback_t	listenerCallback;
+		openavbEndpointParams_VersionCallback_t		versionCallback;
+	} params;
+} openavbEndpointMessage_t;
+
+
+bool startEndpoint(int mode, int ifindex, const char* ifname, unsigned mtu, unsigned link_kbit, unsigned nsr_kbit);
+void stopEndpoint();
+
+#endif // OSAL_ENDPOINT_H

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_maap.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_maap.c
@@ -1,0 +1,596 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include "openavb_platform.h"
+#include "openavb_trace.h"
+#include "openavb_maap.h"
+#include "maap_iface.h"
+#include "openavb_list.h"
+#include "openavb_rawsock.h"
+
+// These are used to support saving the MAAP Address
+#include "openavb_endpoint_cfg.h"
+extern openavb_endpoint_cfg_t x_cfg;
+
+#define	AVB_LOG_COMPONENT	"Endpoint MAAP"
+//#define AVB_LOG_LEVEL AVB_LOG_LEVEL_DEBUG
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+#define MAAP_DYNAMIC_POOL_BASE 0x91E0F0000000LL /**< MAAP dynamic allocation pool base address - Defined in IEEE 1722-2016 Table B.9 */
+#define MAAP_DYNAMIC_POOL_SIZE 0xFE00 /**< MAAP dynamic allocation pool size - Defined in IEEE 1722-2016 Table B.9 */
+
+
+/*******************************************************************************
+ * MAAP proxies
+ ******************************************************************************/
+
+typedef struct {
+	struct ether_addr destAddr;
+	bool taken;
+} maapAlloc_t;
+
+static maapAlloc_t maapAllocList[MAX_AVB_STREAMS];
+static openavbMaapRestartCb_t *maapRestartCallback = NULL;
+static struct ether_addr *maapPreferredAddress = NULL;
+
+static bool maapRunning = FALSE;
+static HANDLE maapThreadHandle;
+static DWORD WINAPI maapThread(LPVOID arg);
+
+enum maapState_t {
+	MAAP_STATE_UNKNOWN,
+	MAAP_STATE_INITIALIZING, // Waiting for initialization
+	MAAP_STATE_REQUESTING, // Waiting address block request
+	MAAP_STATE_CONNECTED, // Have block of addresses
+	MAAP_STATE_RELEASING, // Releasing the block of addresses
+	MAAP_STATE_RELEASED, // Released the block of addresses
+	MAAP_STATE_NOT_AVAILABLE, // MAAP not configured, or freed
+	MAAP_STATE_ERROR
+};
+static enum maapState_t maapState = MAAP_STATE_UNKNOWN;
+static int maapReservationId = 0;
+
+static char maapDaemonPort[6] = {0};
+
+static MUTEX_HANDLE(maapMutex);
+#define MAAP_LOCK() { MUTEX_CREATE_ERR(); MUTEX_LOCK(maapMutex); MUTEX_LOG_ERR("Mutex lock failure"); }
+#define MAAP_UNLOCK() { MUTEX_CREATE_ERR(); MUTEX_UNLOCK(maapMutex); MUTEX_LOG_ERR("Mutex unlock failure"); }
+
+static unsigned long long MaapMacAddrToLongLong(const struct ether_addr *addr)
+{
+	unsigned long long nAddress = 0ull;
+	int i;
+	for (i = 0; i < ETH_ALEN; ++i) {
+		nAddress = (nAddress << 8) | addr->ether_addr_octet[i];
+	}
+	return nAddress;
+}
+
+static void MaapResultToMacAddr(unsigned long long nAddress, struct ether_addr *destAddr)
+{
+	int i;
+	for (i = ETH_ALEN - 1; i >= 0; --i) {
+		destAddr->ether_addr_octet[i] = (U8)(nAddress & 0xFF);
+		nAddress >>= 8;
+	}
+}
+
+static void process_maap_notify(Maap_Notify *mn, int socketfd)
+{
+	assert(mn);
+
+	switch (mn->result)
+	{
+	case MAAP_NOTIFY_ERROR_NONE:
+		/* No error.  Don't display anything. */
+		break;
+	case MAAP_NOTIFY_ERROR_REQUIRES_INITIALIZATION:
+		AVB_LOG_ERROR("MAAP is not initialized, so the command cannot be performed.");
+		break;
+	case MAAP_NOTIFY_ERROR_ALREADY_INITIALIZED:
+		AVB_LOG_ERROR("MAAP is already initialized, so the values cannot be changed.");
+		break;
+	case MAAP_NOTIFY_ERROR_RESERVE_NOT_AVAILABLE:
+		AVB_LOG_ERROR("The MAAP reservation is not available, or yield cannot allocate a replacement block. "
+			"Try again with a smaller address block size.");
+		break;
+	case MAAP_NOTIFY_ERROR_RELEASE_INVALID_ID:
+		AVB_LOG_ERROR("The MAAP reservation ID is not valid, so cannot be released or report its status.");
+		break;
+	case MAAP_NOTIFY_ERROR_OUT_OF_MEMORY:
+		AVB_LOG_ERROR("The MAAP application is out of memory.");
+		break;
+	case MAAP_NOTIFY_ERROR_INTERNAL:
+		AVB_LOG_ERROR("The MAAP application experienced an internal error.");
+		break;
+	default:
+		AVB_LOGF_ERROR("The MAAP application returned an unknown error %d.", mn->result);
+		break;
+	}
+
+	switch (mn->kind)
+	{
+	case MAAP_NOTIFY_INITIALIZED:
+		if (mn->result == MAAP_NOTIFY_ERROR_NONE) {
+			AVB_LOGF_DEBUG("MAAP initialized:  0x%012llx-0x%012llx (Size: %d)",
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				(unsigned int) mn->count);
+
+			// We successfully initialized.  Reserve a block of addresses.
+			Maap_Cmd maapcmd;
+			memset(&maapcmd, 0, sizeof(Maap_Cmd));
+			maapcmd.kind = MAAP_CMD_RESERVE;
+			maapcmd.start = 0; // No preferred address
+			maapcmd.count = MAX_AVB_STREAMS;
+			if (maapPreferredAddress != NULL) {
+				// Suggest the addresses from the previous time this application was run.
+				maapcmd.start = MaapMacAddrToLongLong(maapPreferredAddress);
+				AVB_LOGF_DEBUG("MAAP Preferred Address:  0x%012llx", maapcmd.start);
+			}
+			if (send(socketfd, (char *) &maapcmd, sizeof(Maap_Cmd), 0) < 0)
+			{
+				/* Something went wrong.  Abort! */
+				AVB_LOGF_ERROR("MAAP:  Error %d writing to network socket (%s)", errno, strerror(errno));
+				maapState = MAAP_STATE_ERROR;
+			} else {
+				maapState = MAAP_STATE_REQUESTING;
+			}
+		} else {
+			AVB_LOGF_ERROR("MAAP previously initialized to 0x%012llx-0x%012llx (Size: %d)",
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				(unsigned int) mn->count);
+			maapState = MAAP_STATE_ERROR;
+		}
+		break;
+	case MAAP_NOTIFY_ACQUIRING:
+		if (mn->result == MAAP_NOTIFY_ERROR_NONE) {
+			AVB_LOGF_DEBUG("MAAP address range %d querying:  0x%012llx-0x%012llx (Size %d)",
+				mn->id,
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				mn->count);
+		} else {
+			AVB_LOGF_ERROR("MAAP unknown address range %d acquisition error", mn->id);
+			maapState = MAAP_STATE_ERROR;
+		}
+		break;
+	case MAAP_NOTIFY_ACQUIRED:
+		if (mn->result == MAAP_NOTIFY_ERROR_NONE) {
+			AVB_LOGF_INFO("MAAP address range %d acquired:  0x%012llx-0x%012llx (Size %d)",
+				mn->id,
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				mn->count);
+
+			// Update the stored addresses.
+			MAAP_LOCK();
+			int i = 0;
+			for (i = 0; i < mn->count && i < MAX_AVB_STREAMS; i++) {
+				MaapResultToMacAddr(mn->start + i, &(maapAllocList[i].destAddr));
+				if (maapAllocList[i].taken && maapRestartCallback) {
+					// Use the callback to notify that a change has occurred.
+					MAAP_UNLOCK();
+					maapRestartCallback(&(maapAllocList[i]), &(maapAllocList[i].destAddr));
+					MAAP_LOCK();
+				}
+			}
+			MAAP_UNLOCK();
+
+			// Save the address so we can request it in the future.
+			if (maapPreferredAddress != NULL) {
+				struct ether_addr assignedAddress;
+				MaapResultToMacAddr((unsigned long long) mn->start, &assignedAddress);
+				if (memcmp(maapPreferredAddress, &assignedAddress, sizeof(struct ether_addr)) != 0) {
+					// Save the updated settings.  Done immediately, so they won't get lost on device reboot.
+					memcpy(maapPreferredAddress, &assignedAddress, sizeof(struct ether_addr));
+					openavbSaveConfig(DEFAULT_SAVE_INI_FILE, &x_cfg);
+				}
+			}
+
+			// We now have addresses we can use.
+			maapReservationId = mn->id;
+			maapState = MAAP_STATE_CONNECTED;
+		} else if (mn->id != -1) {
+			AVB_LOGF_ERROR("MAAP address range %d of size %d not acquired",
+				mn->id, mn->count);
+			maapState = MAAP_STATE_ERROR;
+		} else {
+			AVB_LOGF_ERROR("MAAP address range of size %d not acquired",
+				mn->count);
+			maapState = MAAP_STATE_ERROR;
+		}
+		break;
+	case MAAP_NOTIFY_RELEASED:
+		if (mn->result == MAAP_NOTIFY_ERROR_NONE) {
+			AVB_LOGF_DEBUG("MAAP address range %d released:  0x%012llx-0x%012llx (Size %d)",
+				mn->id,
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				mn->count);
+			maapState = MAAP_STATE_RELEASED;
+		} else {
+			AVB_LOGF_WARNING("MAAP address range %d not released",
+				mn->id);
+		}
+		break;
+	case MAAP_NOTIFY_STATUS:
+		if (mn->result == MAAP_NOTIFY_ERROR_NONE) {
+			AVB_LOGF_DEBUG("MAAP ID %d is address range 0x%012llx-0x%012llx (Size %d)",
+				mn->id,
+				(unsigned long long) mn->start,
+				(unsigned long long) mn->start + mn->count - 1,
+				mn->count);
+		} else {
+			AVB_LOGF_DEBUG("MAAP ID %d is not valid",
+				mn->id);
+		}
+		break;
+	case MAAP_NOTIFY_YIELDED:
+		if (mn->result != MAAP_NOTIFY_ERROR_REQUIRES_INITIALIZATION && mn->result != MAAP_NOTIFY_ERROR_RELEASE_INVALID_ID) {
+			if (mn->result != MAAP_NOTIFY_ERROR_NONE) {
+				AVB_LOGF_ERROR("MAAP Address range %d yielded:  0x%012llx-0x%012llx (Size %d).  A new address range will not be allocated.",
+					mn->id,
+					(unsigned long long) mn->start,
+					(unsigned long long) mn->start + mn->count - 1,
+					mn->count);
+				maapState = MAAP_STATE_ERROR;
+			}
+			else {
+				AVB_LOGF_WARNING("MAAP Address range %d yielded:  0x%012llx-0x%012llx (Size %d)",
+					mn->id,
+					(unsigned long long) mn->start,
+					(unsigned long long) mn->start + mn->count - 1,
+					mn->count);
+			}
+		} else {
+			AVB_LOGF_ERROR("ID %d is not valid", mn->id);
+		}
+		break;
+	default:
+		AVB_LOGF_ERROR("MAAP notification type %d not recognized", mn->kind);
+		break;
+	}
+}
+
+
+/* Local function to interact with the MAAP daemon. */
+static DWORD WINAPI maapThread(LPVOID arg)
+{
+        SOCKET socketfd;
+	struct addrinfo hints, *ai, *p;
+	int ret;
+
+	fd_set master, read_fds;
+	int fdmax;
+
+	char recvbuffer[200];
+	int recvbytes;
+	Maap_Cmd maapcmd;
+
+	AVB_LOG_DEBUG("MAAP Thread Starting");
+
+	/* Create a localhost socket. */
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = 0;
+	if ((ret = getaddrinfo("localhost", maapDaemonPort, &hints, &ai)) != 0) {
+		AVB_LOGF_ERROR("getaddrinfo failure %s", gai_strerror(ret));
+		maapState = MAAP_STATE_ERROR;
+		return NULL;
+	}
+
+	for(p = ai; p != NULL; p = p->ai_next) {
+		socketfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+		if (socketfd == -1) {
+			continue;
+		}
+                ret = connect(socketfd, p->ai_addr, (int)p->ai_addrlen);
+                if (ret == SOCKET_ERROR) {
+                        closesocket(socketfd);
+                        continue;
+                } else {
+                        break;
+                }
+	}
+
+	freeaddrinfo(ai);
+
+        if (p == NULL) {
+                AVB_LOGF_ERROR("MAAP:  Unable to connect to the daemon, error %d", WSAGetLastError());
+                maapState = MAAP_STATE_ERROR;
+                return 0;
+        }
+
+        u_long nb = 1;
+        if (ioctlsocket(socketfd, FIONBIO, &nb) != 0)
+        {
+                AVB_LOG_ERROR("MAAP:  Could not set the socket to non-blocking");
+                closesocket(socketfd);
+                maapState = MAAP_STATE_ERROR;
+                return 0;
+        }
+
+        FD_ZERO(&read_fds);
+        FD_ZERO(&master);
+        FD_SET(socketfd, &master);
+        fdmax = (int)socketfd;
+
+	// Initialize the MAAP daemon.
+	// We will request a block of addresses when we get a response to the initialization.
+	maapState = MAAP_STATE_INITIALIZING;
+	memset(&maapcmd, 0, sizeof(Maap_Cmd));
+	maapcmd.kind = MAAP_CMD_INIT;
+	maapcmd.start = MAAP_DYNAMIC_POOL_BASE;
+	maapcmd.count = MAAP_DYNAMIC_POOL_SIZE;
+        if (send(socketfd, (char *) &maapcmd, sizeof(Maap_Cmd), 0) == SOCKET_ERROR)
+        {
+                /* Something went wrong.  Abort! */
+                AVB_LOGF_ERROR("MAAP:  Error %d writing to network socket", WSAGetLastError());
+                maapState = MAAP_STATE_ERROR;
+                return 0;
+        }
+
+
+	/*
+	 * Main event loop
+	 */
+
+	while (maapRunning || maapState <= MAAP_STATE_CONNECTED)
+	{
+		if (!maapRunning && maapState == MAAP_STATE_CONNECTED)
+		{
+			// Tell the MAAP daemon to release the addresses.
+			memset(&maapcmd, 0, sizeof(Maap_Cmd));
+			maapcmd.kind = MAAP_CMD_RELEASE;
+			maapcmd.id = maapReservationId;
+			if (send(socketfd, (char *) &maapcmd, sizeof(Maap_Cmd), 0) > 0)
+			{
+				maapState = MAAP_STATE_RELEASING;
+				// Use the wait below to give the daemon time to respond.
+			}
+			else
+			{
+				maapState = MAAP_STATE_NOT_AVAILABLE;
+				break;
+			}
+		}
+
+		/* Wait for something to happen. */
+		struct timeval tv_timeout = { 1, 0 };
+		read_fds = master;
+                ret = select(fdmax+1, &read_fds, NULL, NULL, &tv_timeout);
+                if (ret == SOCKET_ERROR)
+                {
+                        AVB_LOGF_ERROR("MAAP:  select() error %d", WSAGetLastError());
+                        maapState = MAAP_STATE_ERROR;
+                        break;
+                }
+
+		/* Handle any responses received. */
+		if (FD_ISSET(socketfd, &read_fds))
+		{
+			while ((recvbytes = recv(socketfd, recvbuffer, sizeof(Maap_Notify), 0)) > 0)
+			{
+				recvbuffer[recvbytes] = '\0';
+
+				/* Process the response data (will be binary). */
+				if (recvbytes == sizeof(Maap_Notify))
+				{
+					process_maap_notify((Maap_Notify *) recvbuffer, socketfd);
+				}
+				else
+				{
+					AVB_LOGF_WARNING("MAAP:  Received unexpected response of size %d", recvbytes);
+				}
+			}
+			if (recvbytes == 0)
+			{
+				/* The MAAP daemon closed the connection.  Assume it shut down, and we should too. */
+				// AVDECC_TODO:  Should we try to reconnect?
+				AVB_LOG_ERROR("MAAP daemon exited.");
+				maapState = MAAP_STATE_ERROR;
+				break;
+			}
+                        if (recvbytes < 0 && WSAGetLastError() != WSAEWOULDBLOCK)
+                        {
+                                /* Something went wrong.  Abort! */
+                                AVB_LOGF_ERROR("MAAP:  Error %d reading from network socket", WSAGetLastError());
+                                maapState = MAAP_STATE_ERROR;
+                                break;
+                        }
+		}
+	}
+
+	if (maapState < MAAP_STATE_NOT_AVAILABLE) {
+		maapState = MAAP_STATE_NOT_AVAILABLE;
+	}
+
+        closesocket(socketfd);
+
+        AVB_LOG_DEBUG("MAAP Thread Done");
+        return 0;
+}
+
+bool openavbMaapInitialize(const char *ifname, unsigned int maapPort, struct ether_addr *maapPrefAddr, openavbMaapRestartCb_t* cbfn)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_MAAP);
+
+	// Save the supplied callback function.
+	maapRestartCallback = cbfn;
+	maapPreferredAddress = maapPrefAddr;
+
+	MUTEX_ATTR_HANDLE(mta);
+	MUTEX_ATTR_INIT(mta);
+	MUTEX_ATTR_SET_TYPE(mta, MUTEX_ATTR_TYPE_DEFAULT);
+	MUTEX_ATTR_SET_NAME(mta, "maapMutex");
+	MUTEX_CREATE_ERR();
+	MUTEX_CREATE(maapMutex, mta);
+	MUTEX_LOG_ERR("Could not create/initialize 'maapMutex' mutex");
+
+	// Default to using addresses from the MAAP locally administered Pool.
+	int i = 0;
+	U8 destAddr[ETH_ALEN] = {0x91, 0xe0, 0xf0, 0x00, 0xfe, 0x80};
+	for (i = 0; i < MAX_AVB_STREAMS; i++) {
+		memcpy(maapAllocList[i].destAddr.ether_addr_octet, destAddr, ETH_ALEN);
+		maapAllocList[i].taken = false;
+		destAddr[5] += 1;
+	}
+
+	if (maapPort == 0) {
+		maapState = MAAP_STATE_NOT_AVAILABLE;
+	}
+	else {
+		maapState = MAAP_STATE_UNKNOWN;
+		sprintf(maapDaemonPort, "%u", maapPort);
+
+                maapRunning = TRUE;
+                maapThreadHandle = CreateThread(NULL, 0, maapThread, NULL, 0, NULL);
+                if (!maapThreadHandle) {
+                        maapRunning = FALSE;
+                        maapState = MAAP_STATE_ERROR;
+                        AVB_LOGF_ERROR("Failed to start MAAP thread: %lu", GetLastError());
+                }
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+	return true;
+}
+
+void openavbMaapFinalize()
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_MAAP);
+
+	maapRestartCallback = NULL;
+	maapPreferredAddress = NULL;
+
+	if (maapRunning) {
+		// Stop the MAAP thread.
+                maapRunning = FALSE;
+                WaitForSingleObject(maapThreadHandle, INFINITE);
+                CloseHandle(maapThreadHandle);
+	}
+
+	MUTEX_CREATE_ERR();
+	MUTEX_DESTROY(maapMutex);
+	MUTEX_LOG_ERR("Error destroying mutex");
+
+	AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+}
+
+bool openavbMaapDaemonAvailable(void)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_MAAP);
+
+	if (!maapRunning) {
+		AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+		return FALSE;
+	}
+
+	// Wait up to 10 seconds for the daemon to give us a block of addresses.
+	int j;
+	for (j = 0; j < 10 * 1000 / 50 && maapState < MAAP_STATE_CONNECTED; ++j) {
+		AVB_LOG_DEBUG("Waiting for MAAP Daemon status");
+		SLEEP_MSEC(50);
+	}
+
+	if (maapState != MAAP_STATE_CONNECTED) {
+		if (maapState != MAAP_STATE_NOT_AVAILABLE) {
+			AVB_LOG_WARNING("MAAP Daemon not available.  Fallback multicast address allocation will be used.");
+		}
+		AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+		return FALSE;
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+	return TRUE;
+}
+
+void* openavbMaapAllocate(int count, /* out */ struct ether_addr *addr)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_MAAP);
+	assert(count == 1);
+
+	// Wait up to 10 seconds for the daemon to give us a block of addresses.
+	int j;
+	for (j = 0; j < 10 * 1000 / 50 && maapState < MAAP_STATE_CONNECTED; ++j) {
+		AVB_LOG_DEBUG("Waiting for MAAP Daemon status");
+		SLEEP_MSEC(50);
+	}
+
+	MAAP_LOCK();
+
+	// Find the next non-allocated address.
+	int i = 0;
+	while (i < MAX_AVB_STREAMS && maapAllocList[i].taken) {
+		i++;
+	}
+
+	// Allocate an address from the pool.
+	if (i < MAX_AVB_STREAMS) {
+		maapAllocList[i].taken = true;
+		memcpy(addr, maapAllocList[i].destAddr.ether_addr_octet, sizeof(struct ether_addr));
+		AVB_LOGF_INFO("Allocated MAAP address " ETH_FORMAT, ETH_OCTETS(addr->ether_addr_octet));
+
+		MAAP_UNLOCK();
+
+		AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+		return &maapAllocList[i];
+	}
+
+	MAAP_UNLOCK();
+
+	AVB_LOG_ERROR("All MAAP addresses already allocated");
+	AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+	return NULL;
+}
+
+void openavbMaapRelease(void* handle)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_MAAP);
+
+	MAAP_LOCK();
+	maapAlloc_t *elem = handle;
+	elem->taken = false;
+	AVB_LOGF_DEBUG("Freed MAAP address " ETH_FORMAT, ETH_OCTETS(elem->destAddr.ether_addr_octet));
+	MAAP_UNLOCK();
+
+	AVB_TRACE_EXIT(AVB_TRACE_MAAP);
+}

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_ptp.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_ptp.c
@@ -1,0 +1,75 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "openavb_platform.h"
+#include "openavb_trace.h"
+#include "openavb_endpoint.h"
+
+#define	AVB_LOG_COMPONENT	"Endpoint PTP"
+//#define AVB_LOG_LEVEL AVB_LOG_LEVEL_DEBUG
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+
+inline int startPTP(void)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+
+	// make sure ptp, a separate process, starts and is using the same interface as endpoint
+	int retVal = 0;
+//	char ptpCmd[80];
+//	memset(ptpCmd, 0, 80);
+//	snprintf(ptpCmd, 80, "./openavb_gptp %s -i %s &", x_cfg.ptp_start_opts, x_cfg.ifname);
+//	AVB_LOGF_INFO("PTP start command: %s", ptpCmd);
+//	if (system(ptpCmd) != 0) {
+//		AVB_LOG_ERROR("PTP failed to start - Exiting");
+//		retVal = -1;
+//	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+	return retVal;
+}
+
+inline int stopPTP(void)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+
+	int retVal = 0;
+//	if (system("killall -s SIGINT openavb_gptp") != 0) {
+//		retVal = -1;
+//	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+	return retVal;
+}

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_shaper.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_shaper.c
@@ -1,0 +1,426 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#include "openavb_platform.h"
+#include "openavb_trace.h"
+#include "openavb_shaper.h"
+#include "openavb_list.h"
+#include "openavb_rawsock.h"
+
+#define	AVB_LOG_COMPONENT	"Endpoint Shaper"
+//#define AVB_LOG_LEVEL AVB_LOG_LEVEL_DEBUG
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+
+/*******************************************************************************
+ * Shaper proxies
+ ******************************************************************************/
+
+#define STREAMDA_LENGTH 18
+
+#ifndef IFNAMSIZ
+#define IFNAMSIZ 16
+#endif
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+
+typedef struct shaper_reservation
+{
+	int in_use;
+	SRClassIdx_t sr_class;
+	int measurement_interval; // microseconds
+	int max_frame_size; // bytes
+	int max_frames_per_interval; // number of frames per measurement_interval
+	unsigned char stream_da[ETH_ALEN];
+} shaper_reservation;
+
+#define MAX_SHAPER_RESERVATIONS 4
+static shaper_reservation shaperReservationList[MAX_SHAPER_RESERVATIONS];
+
+static bool shaperRunning = FALSE;
+static HANDLE shaperThreadHandle;
+static DWORD WINAPI shaperThread(LPVOID arg);
+
+enum shaperState_t {
+	SHAPER_STATE_UNKNOWN,
+	SHAPER_STATE_CONNECTED, // Connected, but shaping not enabled.
+	SHAPER_STATE_ENABLED, // Shaping enabled by the daemon
+	SHAPER_STATE_NOT_AVAILABLE, // Daemon not found or not connected.
+	SHAPER_STATE_ERROR
+};
+static enum shaperState_t shaperState = SHAPER_STATE_UNKNOWN;
+
+static int socketfd = -1;
+static char interfaceOnly[IFNAMSIZ];
+static char shaperDaemonPort[6] = {0};
+
+static MUTEX_HANDLE(shaperMutex);
+#define SHAPER_LOCK() { MUTEX_CREATE_ERR(); MUTEX_LOCK(shaperMutex); MUTEX_LOG_ERR("Mutex lock failure"); }
+#define SHAPER_UNLOCK() { MUTEX_CREATE_ERR(); MUTEX_UNLOCK(shaperMutex); MUTEX_LOG_ERR("Mutex unlock failure"); }
+
+
+/* Local function to interact with the SHAPER daemon. */
+static DWORD WINAPI shaperThread(LPVOID arg)
+{
+        struct addrinfo hints, *ai, *p;
+        int ret;
+
+        fd_set master, read_fds;
+        int fdmax;
+
+	char recvbuffer[200];
+	int recvbytes;
+
+	AVB_LOG_DEBUG("Shaper Thread Starting");
+
+	/* Create a localhost socket. */
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = AF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = 0;
+        if ((ret = getaddrinfo("localhost", shaperDaemonPort, &hints, &ai)) != 0) {
+                AVB_LOGF_ERROR("getaddrinfo failure %s", gai_strerror(ret));
+                shaperState = SHAPER_STATE_ERROR;
+                return 0;
+        }
+
+	for(p = ai; p != NULL; p = p->ai_next) {
+		socketfd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+		if (socketfd == -1) {
+			continue;
+		}
+                ret = connect(socketfd, p->ai_addr, (int)p->ai_addrlen);
+                if (ret == SOCKET_ERROR) {
+                        closesocket(socketfd);
+                        socketfd = INVALID_SOCKET;
+                        continue;
+                } else {
+                        break;
+                }
+	}
+
+	freeaddrinfo(ai);
+
+        if (p == NULL) {
+                AVB_LOGF_ERROR("Shaper:  Unable to connect to the daemon, error %d", WSAGetLastError());
+                shaperState = SHAPER_STATE_ERROR;
+                return 0;
+        }
+
+        u_long nb = 1;
+        if (ioctlsocket(socketfd, FIONBIO, &nb) != 0)
+        {
+                AVB_LOG_ERROR("Shaper:  Could not set the socket to non-blocking");
+                closesocket(socketfd);
+                socketfd = INVALID_SOCKET;
+                shaperState = SHAPER_STATE_ERROR;
+                return 0;
+        }
+
+        FD_ZERO(&read_fds);
+        FD_ZERO(&master);
+        FD_SET((SOCKET)socketfd, &master);
+        fdmax = (int)socketfd;
+
+
+	/*
+	 * Main event loop
+	 */
+
+	shaperState = SHAPER_STATE_CONNECTED;
+	AVB_LOG_INFO("Shaper daemon available");
+
+	while (shaperRunning || shaperState == SHAPER_STATE_ENABLED)
+	{
+		if (!shaperRunning && shaperState == SHAPER_STATE_ENABLED)
+		{
+			// TODO:  Tell the SHAPER daemon to stop shaping.
+			break;
+		}
+
+		/* Wait for something to happen. */
+		struct timeval tv_timeout = { 1, 0 };
+		read_fds = master;
+                ret = select(fdmax+1, &read_fds, NULL, NULL, &tv_timeout);
+                if (ret == SOCKET_ERROR)
+                {
+                        AVB_LOGF_ERROR("Shaper:  select() error %d", WSAGetLastError());
+                        shaperState = SHAPER_STATE_ERROR;
+                        break;
+                }
+
+		/* Handle any responses received. */
+		if (FD_ISSET(socketfd, &read_fds))
+		{
+			while ((recvbytes = recv(socketfd, recvbuffer, sizeof(recvbuffer) - 1, 0)) > 0)
+			{
+				/* Log the response data */
+				recvbuffer[recvbytes] = '\0';
+				if (strncmp(recvbuffer, "ERROR:", 6) == 0) {
+					AVB_LOGF_ERROR("Shaper Response:  %s", recvbuffer + 7);
+				}
+				else if (strncmp(recvbuffer, "WARNING:", 8) == 0) {
+					AVB_LOGF_WARNING("Shaper Response:  %s", recvbuffer + 9);
+				}
+				else if (strncmp(recvbuffer, "DEBUG:", 6) == 0) {
+					AVB_LOGF_DEBUG("Shaper Response:  %s", recvbuffer + 7);
+				}
+				else {
+					AVB_LOGF_DEBUG("Shaper Response:  %s", recvbuffer);
+				}
+			}
+			if (recvbytes == 0)
+			{
+				/* The SHAPER daemon closed the connection.  Assume it shut down, and we should too. */
+				// AVDECC_TODO:  Should we try to reconnect?
+				AVB_LOG_ERROR("Shaper daemon exited.");
+				shaperState = SHAPER_STATE_ERROR;
+				break;
+			}
+                        if (recvbytes < 0 && WSAGetLastError() != WSAEWOULDBLOCK)
+                        {
+                                /* Something went wrong.  Abort! */
+                                AVB_LOGF_ERROR("Shaper:  Error %d reading from network socket", WSAGetLastError());
+                                shaperState = SHAPER_STATE_ERROR;
+                                break;
+                        }
+		}
+	}
+
+	if (shaperState < SHAPER_STATE_NOT_AVAILABLE) {
+		shaperState = SHAPER_STATE_NOT_AVAILABLE;
+	}
+
+        closesocket(socketfd);
+        socketfd = INVALID_SOCKET;
+
+        AVB_LOG_DEBUG("Shaper Thread Done");
+        return 0;
+}
+
+bool openavbShaperInitialize(const char *ifname, unsigned int shaperPort)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SHAPER);
+
+	MUTEX_ATTR_HANDLE(mta);
+	MUTEX_ATTR_INIT(mta);
+	MUTEX_ATTR_SET_TYPE(mta, MUTEX_ATTR_TYPE_DEFAULT);
+	MUTEX_ATTR_SET_NAME(mta, "shaperMutex");
+	MUTEX_CREATE_ERR();
+	MUTEX_CREATE(shaperMutex, mta);
+	MUTEX_LOG_ERR("Could not create/initialize 'shaperMutex' mutex");
+
+	memset(shaperReservationList, 0, sizeof(shaperReservationList));
+
+	if (shaperPort == 0) {
+		shaperState = SHAPER_STATE_NOT_AVAILABLE;
+	}
+	else {
+		shaperState = SHAPER_STATE_UNKNOWN;
+		sprintf(shaperDaemonPort, "%u", shaperPort);
+
+		// Save the interface-only name to pass to the daemon later.
+		const char *ifonly = strchr(ifname, ':');
+		if (ifonly) {
+			ifonly++; // Go past the colon
+		} else {
+			ifonly = ifname; // No colon in interface name
+		}
+		strncpy(interfaceOnly, ifonly, sizeof(interfaceOnly));
+		interfaceOnly[sizeof(interfaceOnly) - 1] = '\0';
+
+                shaperRunning = TRUE;
+                shaperThreadHandle = CreateThread(NULL, 0, shaperThread, NULL, 0, NULL);
+                if (!shaperThreadHandle) {
+                        shaperRunning = FALSE;
+                        shaperState = SHAPER_STATE_ERROR;
+                        AVB_LOGF_ERROR("Failed to start SHAPER thread: %lu", GetLastError());
+                }
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SHAPER);
+	return true;
+}
+
+void openavbShaperFinalize()
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SHAPER);
+
+	if (shaperRunning) {
+		// Stop the SHAPER thread.
+		shaperRunning = FALSE;
+                WaitForSingleObject(shaperThreadHandle, INFINITE);
+                CloseHandle(shaperThreadHandle);
+	}
+
+	MUTEX_CREATE_ERR();
+	MUTEX_DESTROY(shaperMutex);
+	MUTEX_LOG_ERR("Error destroying mutex");
+
+	AVB_TRACE_EXIT(AVB_TRACE_SHAPER);
+}
+
+bool openavbShaperDaemonAvailable(void)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SHAPER);
+
+	if (!shaperRunning) {
+		AVB_TRACE_EXIT(AVB_TRACE_SHAPER);
+		return FALSE;
+	}
+
+	// Wait for the daemon to connect.
+	if (shaperState == SHAPER_STATE_UNKNOWN) {
+		SLEEP_MSEC(50);
+	}
+
+	if (shaperState > SHAPER_STATE_UNKNOWN && shaperState < SHAPER_STATE_NOT_AVAILABLE) {
+		AVB_TRACE_EXIT(AVB_TRACE_SHAPER);
+		return TRUE;
+	}
+
+	if (shaperState != SHAPER_STATE_NOT_AVAILABLE) {
+		AVB_LOG_WARNING("Shaper Daemon not available.");
+	}
+	AVB_TRACE_EXIT(AVB_TRACE_SHAPER);
+	return FALSE;
+}
+
+void* openavbShaperHandle(SRClassIdx_t sr_class, int measurement_interval_usec, int max_frame_size_bytes, int max_frames_per_interval, const unsigned char * stream_da)
+{
+	// If the daemon is not available, abort!
+	if (socketfd == -1 || !openavbShaperDaemonAvailable())
+	{
+		AVB_LOG_ERROR("Shaper reservation attempted with no daemon available");
+		return NULL;
+	}
+
+	// Find the first available index.
+	int i;
+	for (i = 0; i < MAX_SHAPER_RESERVATIONS; ++i)
+	{
+		if (!(shaperReservationList[i].in_use))
+		{
+			break;
+		}
+	}
+	if (i >= MAX_SHAPER_RESERVATIONS)
+	{
+		AVB_LOG_ERROR("No Shaper reservations are available");
+		return NULL;
+	}
+
+	// Fill in the information.
+	shaperReservationList[i].in_use = TRUE;
+	shaperReservationList[i].sr_class = sr_class;
+	shaperReservationList[i].measurement_interval = measurement_interval_usec;
+	shaperReservationList[i].max_frame_size = max_frame_size_bytes;
+	shaperReservationList[i].max_frames_per_interval = max_frames_per_interval;
+	memcpy(shaperReservationList[i].stream_da, stream_da, ETH_ALEN);
+
+	// Send the information to the Shaper daemon.
+	// Reserving Bandwidth Example:  -ri eth2 -c A -s 125 -b 74 -f 1 -a ff:ff:ff:ff:ff:11\n
+	char szCommand[200];
+	sprintf(szCommand, "-ri %s -c %c -s %u -b %u -f %u -a %02x:%02x:%02x:%02x:%02x:%02x",
+		interfaceOnly,
+		( shaperReservationList[i].sr_class == SR_CLASS_A ? 'A' : 'B' ),
+		shaperReservationList[i].measurement_interval,
+		shaperReservationList[i].max_frame_size,
+		shaperReservationList[i].max_frames_per_interval,
+		shaperReservationList[i].stream_da[0],
+		shaperReservationList[i].stream_da[1],
+		shaperReservationList[i].stream_da[2],
+		shaperReservationList[i].stream_da[3],
+		shaperReservationList[i].stream_da[4],
+		shaperReservationList[i].stream_da[5]);
+	AVB_LOGF_DEBUG("Sending Shaper command:  %s", szCommand);
+	strcat(szCommand, "\n");
+        if (send(socketfd, szCommand, (int)strlen(szCommand), 0) == SOCKET_ERROR)
+        {
+                /* Something went wrong.  Abort! */
+                AVB_LOGF_ERROR("Shaper:  Error %d writing to network socket", WSAGetLastError());
+                shaperState = SHAPER_STATE_ERROR;
+                return NULL;
+        }
+
+	shaperState = SHAPER_STATE_ENABLED;
+
+	// TODO:  Verify that the command was successful.
+
+	return (void *)(&(shaperReservationList[i]));
+}
+
+void openavbShaperRelease(void* handle)
+{
+	int i;
+	for (i = 0; i < MAX_SHAPER_RESERVATIONS; ++i)
+	{
+		if (handle == (void *)(&(shaperReservationList[i])))
+		{
+			if (shaperReservationList[i].in_use)
+			{
+				// Send the information to the Shaper daemon.
+				// Unreserving Bandwidth Example:  -ua ff:ff:ff:ff:ff:11\n
+				char szCommand[200];
+				sprintf(szCommand, "-ua %02x:%02x:%02x:%02x:%02x:%02x",
+					shaperReservationList[i].stream_da[0],
+					shaperReservationList[i].stream_da[1],
+					shaperReservationList[i].stream_da[2],
+					shaperReservationList[i].stream_da[3],
+					shaperReservationList[i].stream_da[4],
+					shaperReservationList[i].stream_da[5]);
+
+				shaperReservationList[i].in_use = FALSE;
+
+				AVB_LOGF_DEBUG("Sending Shaper command:  %s", szCommand);
+				strcat(szCommand, "\n");
+                                if (send(socketfd, szCommand, (int)strlen(szCommand), 0) == SOCKET_ERROR)
+                                {
+                                        /* Something went wrong. */
+                                        AVB_LOGF_ERROR("Shaper:  Error %d writing to network socket", WSAGetLastError());
+                                        shaperState = SHAPER_STATE_ERROR;
+                                }
+				else {
+					// TODO:  Verify that the command was successful.
+				}
+			}
+			break;
+		}
+	}
+}

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_srp.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_srp.c
@@ -1,0 +1,412 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "openavb_platform.h"
+#include "openavb_trace.h"
+#include "openavb_endpoint.h"
+#include "openavb_srp.h"
+#include "mrp_client.h"
+#include "openavb_list.h"
+
+#define	AVB_LOG_COMPONENT	"Endpoint SRP"
+//#define AVB_LOG_LEVEL AVB_LOG_LEVEL_DEBUG
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+
+/*******************************************************************************
+ * SRP proxies
+ ******************************************************************************/
+
+static strmAttachCb_t _attachCb = NULL;
+static strmRegCb_t _registerCb = NULL;
+
+typedef struct {
+	void* avtpHandle;
+	bool talker;
+	U8 streamId[8];
+	U8 destAddr[6];
+	U16 vlanId;
+	int maxFrameSize;
+	int maxIntervalFrames;
+	int priority;
+	int latency;
+	int subtype;
+} strElem_t;
+
+openavb_list_t strElemList;
+
+#define SID_FORMAT "%02x:%02x:%02x:%02x:%02x:%02x/%u"
+#define SID_OCTETS(a) (a)[0],(a)[1],(a)[2],(a)[3],(a)[4],(a)[5],(a)[6]<<8|(a)[7]
+
+// Callback for SRP to notify AVTP Talker that a Listener Declaration has been
+// registered (or de-registered)
+void mrp_attach_cb(unsigned char streamid[8], int subtype)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+
+	AVB_LOGF_DEBUG("mrp_attach_cb "SID_FORMAT" subtype %d", SID_OCTETS(streamid), subtype);
+
+	if (_attachCb) {
+		openavb_list_node_t node = openavbListIterFirst(strElemList);
+		while (node) {
+			strElem_t *elem = openavbListData(node);
+			if (elem && elem->talker && memcmp(streamid, elem->streamId, sizeof(elem->streamId)) == 0) {
+				_attachCb(elem->avtpHandle, subtype);
+				elem->subtype = subtype;
+				AVB_LOGF_DEBUG("mrp_attach_cb subtype changed to %d", elem->subtype);
+				break;
+			}
+			else if (elem) {
+				AVB_LOGF_DEBUG("mrp_attach_cb skipping elem " SID_FORMAT ", talker %d",
+					SID_OCTETS(elem->streamId), elem->talker ? 1 : 0);
+			}
+			node = openavbListIterNext(strElemList);
+		}
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+}
+
+// Callback for SRP to notify AVTP Listener that a Talker Declaration has been
+// registered (or de-registered)
+void mrp_register_cb(unsigned char streamid[8], int join, unsigned char destaddr[6], unsigned int max_frame_size, unsigned int max_interval_frames, uint16_t vid, unsigned int latency)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+
+	AVB_LOGF_DEBUG("mrp_register_cb "SID_FORMAT" "ETH_FORMAT" join %d max_frame_size %d max_interval_frames %d vid %d latency %d",
+	             SID_OCTETS(streamid), ETH_OCTETS(destaddr), join, max_frame_size, max_interval_frames, vid, latency);
+
+	if (_registerCb) {
+		openavb_list_node_t node = openavbListIterFirst(strElemList);
+		while (node) {
+			strElem_t *elem = openavbListData(node);
+			if (elem && !elem->talker && memcmp(streamid, elem->streamId, sizeof(elem->streamId)) == 0) {
+				AVBTSpec_t tSpec;
+				tSpec.maxFrameSize = max_frame_size;
+				tSpec.maxIntervalFrames = max_interval_frames;
+				_registerCb(elem->avtpHandle,
+						join ? openavbSrp_AtTyp_TalkerAdvertise : openavbSrp_AtTyp_None,
+						destaddr,
+						&tSpec,
+						0, // SR_CLASS is ignored anyway
+						latency,
+						NULL
+						);
+				elem->subtype = join;
+				AVB_LOGF_DEBUG("mrp_register_cb subtype changed to %d", elem->subtype);
+				break;
+			}
+			else if (elem) {
+				AVB_LOGF_DEBUG("mrp_register_cb skipping elem " SID_FORMAT ", talker %d",
+					SID_OCTETS(elem->streamId), elem->talker ? 1 : 0);
+			}
+			node = openavbListIterNext(strElemList);
+		}
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+}
+
+openavbRC openavbSrpInitialize(strmAttachCb_t attachCb, strmRegCb_t registerCb,
+                               char* ifname, U32 TxRateKbps, bool bypassAsCapableCheck)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+	int err;
+
+	strElemList = openavbListNewList();
+
+	_attachCb = attachCb;
+	_registerCb = registerCb;
+
+
+	err = mrp_connect();
+	if (err) {
+		AVB_LOGF_ERROR("mrp_connect failed: %s", strerror(errno));
+		goto error;
+	}
+	err = mrp_monitor();
+	if (err) {
+		AVB_LOGF_ERROR("failed creating MRP monitor thread: %s", strerror(errno));
+		goto error;
+	}
+
+	int class_a_id, a_priority;
+	u_int16_t  a_vid;
+	int class_b_id, b_priority;
+	u_int16_t b_vid;
+
+	err = mrp_get_domain(&class_a_id,&a_priority, &a_vid, &class_b_id, &b_priority, &b_vid);
+	if (err) {
+		AVB_LOG_DEBUG("mrp_get_domain failed");
+		goto error;
+	}
+
+	AVB_LOGF_INFO("detected domain Class A PRIO=%d VID=%04x...", a_priority, (int)a_vid);
+	AVB_LOGF_INFO("detected domain Class B PRIO=%d VID=%04x...", b_priority, (int)b_vid);
+
+	err = mrp_register_domain(&domain_class_a_id, &domain_class_a_priority, &domain_class_a_vid);
+	if (err) {
+		AVB_LOG_DEBUG("mrp_register_domain failed");
+		goto error;
+	}
+
+	err = mrp_register_domain(&domain_class_b_id, &domain_class_b_priority, &domain_class_b_vid);
+	if (err) {
+		AVB_LOG_DEBUG("mrp_register_domain failed");
+		goto error;
+	}
+
+	err = mrp_join_vlan();
+	if (err) {
+		AVB_LOG_DEBUG("mrp_join_vlan failed");
+		goto error;
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+
+error:
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_FAILURE;
+}
+
+void openavbSrpShutdown(void)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+	int err = mrp_disconnect();
+	if (err) {
+		AVB_LOGF_ERROR("mrp_disconnect failed: %s", strerror(errno));
+	}
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+}
+
+openavbRC openavbSrpRegisterStream(void* avtpHandle,
+                                   AVBStreamID_t* _streamId,
+                                   U8 DA[],
+                                   AVBTSpec_t* tSpec,
+                                   SRClassIdx_t SRClassIdx,
+                                   bool Rank,
+                                   U32 Latency)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+	int err;
+
+	// convert streamId to 8 byte format
+	uint8_t streamId[8];
+	memcpy(streamId, _streamId->addr, sizeof(_streamId->addr));
+	streamId[6] = _streamId->uniqueID >> 8;
+	streamId[7] = _streamId->uniqueID & 0xFF;
+
+	openavb_list_node_t node = openavbListNew(strElemList, sizeof(strElem_t));
+	strElem_t* elem = openavbListData(node);
+
+	elem->avtpHandle = avtpHandle;
+	elem->talker = true;
+	memcpy(elem->streamId, streamId, sizeof(elem->streamId));
+	memcpy(elem->destAddr, DA, sizeof(elem->destAddr));
+	elem->maxFrameSize = tSpec->maxFrameSize;
+	elem->maxIntervalFrames = tSpec->maxIntervalFrames;
+	elem->latency = Latency;
+	elem->subtype = openavbSrp_LDSt_None;
+
+	switch (SRClassIdx) {
+	case SR_CLASS_A:
+		elem->vlanId = domain_class_a_vid;
+		elem->priority = domain_class_a_priority;
+
+		err = mrp_advertise_stream(streamId,
+		                     DA,
+		                     domain_class_a_vid,
+		                     tSpec->maxFrameSize,
+		                     tSpec->maxIntervalFrames,
+		                     domain_class_a_priority,
+		                     Latency);
+		break;
+	case SR_CLASS_B:
+		elem->vlanId = domain_class_b_vid;
+		elem->priority = domain_class_b_priority;
+
+		err = mrp_advertise_stream(streamId,
+		                     DA,
+		                     domain_class_b_vid,
+		                     tSpec->maxFrameSize,
+		                     tSpec->maxIntervalFrames,
+		                     domain_class_b_priority,
+		                     Latency);
+		break;
+	default:
+		AVB_LOGF_ERROR("unknown SRClassIdx %d", (int)SRClassIdx);
+		goto error;
+	}
+
+	if (err) {
+		AVB_LOG_ERROR("mrp_advertise_stream failed");
+		goto error;
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+
+error:
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_FAILURE;
+}
+
+openavbRC openavbSrpDeregisterStream(AVBStreamID_t* _streamId)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+
+	// convert streamId to 8 byte format
+	uint8_t streamId[8];
+	memcpy(streamId, _streamId->addr, sizeof(_streamId->addr));
+	streamId[6] = _streamId->uniqueID >> 8;
+	streamId[7] = _streamId->uniqueID & 0xFF;
+
+	openavb_list_node_t node = openavbListIterFirst(strElemList);
+	while (node) {
+		strElem_t *elem = openavbListData(node);
+		if (elem && memcmp(streamId, elem->streamId, sizeof(elem->streamId)) == 0) {
+			int err = mrp_unadvertise_stream(elem->streamId, elem->destAddr, elem->vlanId, elem->maxFrameSize, elem->maxIntervalFrames, elem->priority, elem->latency);
+			if (err) {
+				AVB_LOG_ERROR("mrp_unadvertise_stream failed");
+			}
+			openavbListDelete(strElemList, node);
+			break;
+		}
+		node = openavbListIterNext(strElemList);
+	}
+	if (!node)
+		AVB_LOGF_ERROR("%s: unknown stream "SID_FORMAT, __func__, SID_OCTETS(streamId));
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+}
+
+openavbRC openavbSrpAttachStream(void* avtpHandle,
+                                 AVBStreamID_t* _streamId,
+                                 openavbSrpLsnrDeclSubtype_t type)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+
+	// convert streamId to 8 byte format
+	uint8_t streamId[8];
+	memcpy(streamId, _streamId->addr, sizeof(_streamId->addr));
+	streamId[6] = _streamId->uniqueID >> 8;
+	streamId[7] = _streamId->uniqueID & 0xFF;
+
+	AVB_LOGF_DEBUG("openavbSrpAttachStream "SID_FORMAT, SID_OCTETS(streamId));
+
+	openavb_list_node_t node = openavbListIterFirst(strElemList);
+	// lets check if this streamId is on our list
+	while (node) {
+		strElem_t *elem = openavbListData(node);
+		if (elem && memcmp(streamId, elem->streamId, sizeof(elem->streamId)) == 0) {
+			break;
+		}
+		node = openavbListIterNext(strElemList);
+	}
+	if (!node) {
+		// not found so add it
+		node = openavbListNew(strElemList, sizeof(strElem_t));
+		strElem_t* elem = openavbListData(node);
+
+		elem->avtpHandle = avtpHandle;
+		elem->talker = false;
+		memcpy(elem->streamId, streamId, sizeof(elem->streamId));
+		elem->subtype = type;
+	}
+
+	int err = mrp_send_ready(streamId);
+	if (err) {
+		AVB_LOG_ERROR("mrp_send_ready failed");
+	}
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+}
+
+openavbRC openavbSrpDetachStream(AVBStreamID_t* _streamId)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+
+	// convert streamId to 8 byte format
+	uint8_t streamId[8];
+	memcpy(streamId, _streamId->addr, sizeof(_streamId->addr));
+	streamId[6] = _streamId->uniqueID >> 8;
+	streamId[7] = _streamId->uniqueID & 0xFF;
+
+	AVB_LOGF_DEBUG("openavbSrpDetachStream "SID_FORMAT, SID_OCTETS(streamId));
+
+	openavb_list_node_t node = openavbListIterFirst(strElemList);
+	while (node) {
+		strElem_t *elem = openavbListData(node);
+		if (elem && memcmp(streamId, elem->streamId, sizeof(elem->streamId)) == 0) {
+			int err = mrp_send_leave(streamId);
+			if (err) {
+				AVB_LOG_ERROR("mrp_send_leave failed");
+			}
+			openavbListDelete(strElemList, node);
+			break;
+		}
+		node = openavbListIterNext(strElemList);
+	}
+	if (!node)
+		AVB_LOGF_ERROR("%s: unknown stream "SID_FORMAT, __func__, SID_OCTETS(streamId));
+
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+}
+
+openavbRC openavbSrpGetClassParams(SRClassIdx_t SRClassIdx, U8* priority, U16* vid, U32* inverseIntervalSec)
+{
+	AVB_TRACE_ENTRY(AVB_TRACE_SRP_PUBLIC);
+	switch (SRClassIdx) {
+	case SR_CLASS_A:
+		*priority = domain_class_a_priority;
+		*vid = domain_class_a_vid;
+		*inverseIntervalSec = 8000;
+		break;
+	case SR_CLASS_B:
+		*priority = domain_class_b_priority;
+		*vid = domain_class_b_vid;
+		*inverseIntervalSec = 4000;
+		break;
+	default:
+		AVB_LOGF_ERROR("unknown SRClassIdx %d", (int)SRClassIdx);
+		AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+		return OPENAVB_SRP_FAILURE;
+	}
+	AVB_TRACE_EXIT(AVB_TRACE_SRP_PUBLIC);
+	return OPENAVB_SRP_SUCCESS;
+}

--- a/lib/avtp_pipeline/platform/Windows/openavb_grandmaster_osal.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_grandmaster_osal.c
@@ -1,0 +1,59 @@
+#include "openavb_platform.h"
+#include "openavb_grandmaster_osal.h"
+#include "openavb_trace.h"
+
+#define AVB_LOG_COMPONENT       "osalGrandmaster"
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+// Windows does not currently provide a gPTP shared memory interface.
+// These functions are stubs so that the library can link.
+
+bool osalAVBGrandmasterInit(void)
+{
+    AVB_LOG_WARNING("Grandmaster support not implemented on Windows");
+    return TRUE;
+}
+
+bool osalAVBGrandmasterClose(void)
+{
+    return TRUE;
+}
+
+bool osalAVBGrandmasterGetCurrent(
+        uint8_t gptp_grandmaster_id[],
+        uint8_t * gptp_domain_number )
+{
+    if (gptp_grandmaster_id) memset(gptp_grandmaster_id, 0, 8);
+    if (gptp_domain_number) *gptp_domain_number = 0;
+    AVB_LOG_WARNING("Grandmaster data unavailable on Windows");
+    return TRUE;
+}
+
+bool osalClockGrandmasterGetInterface(
+        uint8_t clock_identity[],
+        uint8_t * priority1,
+        uint8_t * clock_class,
+        int16_t * offset_scaled_log_variance,
+        uint8_t * clock_accuracy,
+        uint8_t * priority2,
+        uint8_t * domain_number,
+        int8_t * log_sync_interval,
+        int8_t * log_announce_interval,
+        int8_t * log_pdelay_interval,
+        uint16_t * port_number)
+{
+    if (clock_identity) memset(clock_identity, 0, 8);
+    if (priority1) *priority1 = 0;
+    if (clock_class) *clock_class = 0;
+    if (offset_scaled_log_variance) *offset_scaled_log_variance = 0;
+    if (clock_accuracy) *clock_accuracy = 0;
+    if (priority2) *priority2 = 0;
+    if (domain_number) *domain_number = 0;
+    if (log_sync_interval) *log_sync_interval = 0;
+    if (log_announce_interval) *log_announce_interval = 0;
+    if (log_pdelay_interval) *log_pdelay_interval = 0;
+    if (port_number) *port_number = 0;
+    AVB_LOG_WARNING("Grandmaster interface data unavailable on Windows");
+    return TRUE;
+}

--- a/lib/avtp_pipeline/platform/Windows/openavb_osal.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_osal.c
@@ -1,0 +1,91 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <windows.h>
+#include <winsock2.h>
+
+#include "openavb_platform.h"
+#include "openavb_osal.h"
+#include "openavb_qmgr.h"
+
+#define	AVB_LOG_COMPONENT	"osal"
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+static FILE *s_logfile = NULL;
+static bool s_wsa_started = FALSE;
+
+extern DLL_EXPORT bool osalAVBInitialize(const char* logfilename, const char* ifname)
+{
+        if (!s_wsa_started) {
+                WSADATA data;
+                if (WSAStartup(MAKEWORD(2,2), &data) == 0) {
+                        s_wsa_started = TRUE;
+                }
+        }
+        // Open the log file, if requested.
+        if (s_logfile) {
+                fclose(s_logfile);
+                s_logfile = NULL;
+        }
+        if (logfilename) {
+                fopen_s(&s_logfile, logfilename, "w");
+                if (s_logfile == NULL) {
+                        fprintf(stderr, "Error opening log file: %s\n", logfilename);
+                }
+        }
+
+	avbLogInitEx(s_logfile);
+	osalAVBTimeInit();
+	openavbQmgrInitialize(FQTSS_MODE_HW_CLASS, 0, ifname, 0, 0, 0);
+	return TRUE;
+}
+
+extern DLL_EXPORT bool osalAVBFinalize(void)
+{
+        openavbQmgrFinalize();
+        osalAVBTimeClose();
+        avbLogExit();
+
+        if (s_wsa_started) {
+                WSACleanup();
+                s_wsa_started = FALSE;
+        }
+
+	// Done with the log file.
+        if (s_logfile) {
+                fclose(s_logfile);
+                s_logfile = NULL;
+        }
+
+	return TRUE;
+}
+

--- a/lib/avtp_pipeline/platform/Windows/openavb_osal_avdecc.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_osal_avdecc.c
@@ -1,0 +1,94 @@
+/*************************************************************************************************************
+Copyright (c) 2012-2015, Symphony Teleca Corporation, a Harman International Industries, Incorporated company
+Copyright (c) 2016-2017, Harman International Industries, Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS LISTED "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS LISTED BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Attributions: The inih library portion of the source code is licensed from
+Brush Technology and Ben Hoyt - Copyright (c) 2009, Brush Technology and Copyright (c) 2009, Ben Hoyt.
+Complete license and copyright information can be found at
+https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
+*************************************************************************************************************/
+
+#include <windows.h>
+#include <winsock2.h>
+
+#include "openavb_platform.h"
+#include "openavb_osal.h"
+#include "openavb_qmgr.h"
+#include "openavb_avdecc.h"
+
+#define	AVB_LOG_COMPONENT	"osal"
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+static FILE *s_logfile = NULL;
+static bool s_wsa_started = FALSE;
+
+extern DLL_EXPORT bool osalAvdeccInitialize(const char* logfilename, const char* ifname, const char **inifiles, int numfiles)
+{
+        if (!s_wsa_started) {
+                WSADATA data;
+                if (WSAStartup(MAKEWORD(2,2), &data) == 0) {
+                        s_wsa_started = TRUE;
+                }
+        }
+        // Open the log file, if requested.
+        if (s_logfile) {
+                fclose(s_logfile);
+                s_logfile = NULL;
+        }
+        if (logfilename) {
+                fopen_s(&s_logfile, logfilename, "w");
+                if (s_logfile == NULL) {
+                        fprintf(stderr, "Error opening log file: %s\n", logfilename);
+                }
+        }
+
+	avbLogInitEx(s_logfile);
+	osalAVBTimeInit();
+	if (!osalAVBGrandmasterInit()) { return FALSE; }
+	if (!startAvdecc(ifname, inifiles, numfiles)) { return FALSE; }
+	return TRUE;
+}
+
+extern DLL_EXPORT bool osalAvdeccFinalize(void)
+{
+        stopAvdecc();
+        osalAVBGrandmasterClose();
+        osalAVBTimeClose();
+        avbLogExit();
+
+        if (s_wsa_started) {
+                WSACleanup();
+                s_wsa_started = FALSE;
+        }
+
+	// Done with the log file.
+        if (s_logfile) {
+                fclose(s_logfile);
+                s_logfile = NULL;
+        }
+
+	return TRUE;
+}
+

--- a/lib/avtp_pipeline/platform/Windows/openavb_time_osal.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_time_osal.c
@@ -1,0 +1,59 @@
+#include <windows.h>
+#include <stdio.h>
+#include "openavb_platform.h"
+#include "openavb_time_osal.h"
+#include "openavb_trace.h"
+
+#define AVB_LOG_COMPONENT       "osalTime"
+#include "openavb_pub.h"
+#include "openavb_log.h"
+
+static LARGE_INTEGER gFreq;
+static BOOL gInit = FALSE;
+
+bool osalAVBTimeInit(void)
+{
+    if (!QueryPerformanceFrequency(&gFreq))
+        return FALSE;
+    gInit = TRUE;
+    return TRUE;
+}
+
+bool osalAVBTimeClose(void)
+{
+    return TRUE;
+}
+
+static void perfToTimespec(LARGE_INTEGER counter, struct timespec *ts)
+{
+    double secs = (double)counter.QuadPart / (double)gFreq.QuadPart;
+    ts->tv_sec = (time_t)secs;
+    ts->tv_nsec = (long)((secs - ts->tv_sec) * 1e9);
+}
+
+bool osalClockGettime(openavb_clockId_t clockId, struct timespec *tp)
+{
+    if (!gInit && !osalAVBTimeInit())
+        return FALSE;
+
+    if (clockId == OPENAVB_CLOCK_MONOTONIC || clockId == OPENAVB_TIMER_CLOCK) {
+        LARGE_INTEGER c; QueryPerformanceCounter(&c); perfToTimespec(c, tp); return TRUE;
+    }
+    else {
+        FILETIME ft; GetSystemTimeAsFileTime(&ft);
+        ULONGLONG t = ((ULONGLONG)ft.dwHighDateTime << 32) | ft.dwLowDateTime;
+        t -= 116444736000000000ULL; /* epoch */
+        tp->tv_sec = (long)(t / 10000000ULL);
+        tp->tv_nsec = (long)((t % 10000000ULL) * 100);
+        return TRUE;
+    }
+}
+
+bool osalClockGettime64(openavb_clockId_t clockId, U64 *ns)
+{
+    struct timespec ts;
+    if (!osalClockGettime(clockId, &ts))
+        return FALSE;
+    *ns = ((U64)ts.tv_sec * 1000000000ULL) + ts.tv_nsec;
+    return TRUE;
+}


### PR DESCRIPTION
## Summary
- implement Windows variants of AVB OSAL libraries
- create Windows endpoint implementations using Win32 threads and sockets
- provide high resolution timer support via `QueryPerformanceCounter`
- add stubbed grandmaster implementation on Windows

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_685794dbb02c8322abec7a38fbcaaf4f