### PR TITLE
Implement gPTP management on Windows

### DIFF
--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_ptp.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_ptp.c
@@ -31,6 +31,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include <stdlib.h>
 #include <string.h>
+#include <windows.h>
 
 #include "openavb_platform.h"
 #include "openavb_trace.h"
@@ -41,35 +42,61 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #include "openavb_pub.h"
 #include "openavb_log.h"
 
+static PROCESS_INFORMATION gptpProcInfo;
+
 
 inline int startPTP(void)
 {
-	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+        AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
 
-	// make sure ptp, a separate process, starts and is using the same interface as endpoint
-	int retVal = 0;
-//	char ptpCmd[80];
-//	memset(ptpCmd, 0, 80);
-//	snprintf(ptpCmd, 80, "./openavb_gptp %s -i %s &", x_cfg.ptp_start_opts, x_cfg.ifname);
-//	AVB_LOGF_INFO("PTP start command: %s", ptpCmd);
-//	if (system(ptpCmd) != 0) {
-//		AVB_LOG_ERROR("PTP failed to start - Exiting");
-//		retVal = -1;
-//	}
+        // Spawn gPTP daemon so that it uses the same network interface as the endpoint
+        int retVal = -1;
+        char cmdLine[256];
+        STARTUPINFO si;
 
-	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
-	return retVal;
+        ZeroMemory(&gptpProcInfo, sizeof(gptpProcInfo));
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+
+        snprintf(cmdLine, sizeof(cmdLine), "openavb_gptp %s -i %s",
+                         x_cfg.ptp_start_opts ? x_cfg.ptp_start_opts : "",
+                         x_cfg.ifname);
+        AVB_LOGF_INFO("PTP start command: %s", cmdLine);
+
+        if (CreateProcess(NULL, cmdLine, NULL, NULL, FALSE,
+                          CREATE_NEW_PROCESS_GROUP, NULL, NULL,
+                          &si, &gptpProcInfo)) {
+                WaitForInputIdle(gptpProcInfo.hProcess, 5000);
+                retVal = 0;
+        } else {
+                AVB_LOGF_ERROR("PTP failed to start - error %lu", GetLastError());
+        }
+
+        AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+        return retVal;
 }
 
 inline int stopPTP(void)
 {
-	AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
+        AVB_TRACE_ENTRY(AVB_TRACE_ENDPOINT);
 
-	int retVal = 0;
-//	if (system("killall -s SIGINT openavb_gptp") != 0) {
-//		retVal = -1;
-//	}
+        int retVal = 0;
 
-	AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
-	return retVal;
+        if (gptpProcInfo.hProcess) {
+                if (GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, gptpProcInfo.dwProcessId)) {
+                        WaitForSingleObject(gptpProcInfo.hProcess, 5000);
+                }
+
+                if (WaitForSingleObject(gptpProcInfo.hProcess, 0) != WAIT_OBJECT_0) {
+                        TerminateProcess(gptpProcInfo.hProcess, 0);
+                        WaitForSingleObject(gptpProcInfo.hProcess, INFINITE);
+                }
+
+                CloseHandle(gptpProcInfo.hProcess);
+                CloseHandle(gptpProcInfo.hThread);
+                ZeroMemory(&gptpProcInfo, sizeof(gptpProcInfo));
+        }
+
+        AVB_TRACE_EXIT(AVB_TRACE_ENDPOINT);
+        return retVal;
 }


### PR DESCRIPTION
## Summary
- spawn gPTP using `CreateProcess` on Windows
- wait for startup and allow clean shutdown

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68579e87774c8322a3f721fa61c857f1