### PR TITLE
Fix GitHub Actions submodules

### DIFF
--- a/.github/workflows/OpenAvnu_Build.yml
+++ b/.github/workflows/OpenAvnu_Build.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          submodules: false  # wir setzen die URLs gleich manuell
+          submodules: recursive
+
+      - name: Verify CppUTest submodule
+        run: test -f thirdparty/cpputest/CMakeLists.txt
 
       - name: Set up dependencies
         run: |
@@ -30,14 +33,6 @@ jobs:
             libpci-dev libsndfile1-dev libjack-dev \
             libasound2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
-      - name: Fix submodule URLs
-        run: |
-          git config --file .gitmodules submodule.avdecc-lib.url https://github.com/AVnu/avdecc-lib.git
-          git config --file .gitmodules submodule.lib/atl_avb.url https://github.com/zarfld/atl_avb.git
-          git config --file .gitmodules submodule.lib/igb_avb.url https://github.com/AVnu/igb_avb.git
-          git config --file .gitmodules submodule.thirdparty/cpputest.url https://github.com/cpputest/cpputest.git
-          git submodule sync
-          git submodule update --init --recursive
 
       - name: Build daemons/maap seperately
         run: |

--- a/.github/workflows/travis_sh.yml
+++ b/.github/workflows/travis_sh.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Verify CppUTest submodule
+        run: test -f thirdparty/cpputest/CMakeLists.txt
 
       - name: Install dependencies
         run: |
@@ -33,14 +38,6 @@ jobs:
             libpci-dev libsndfile1-dev libjack-dev \
             libasound2-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 
-      - name: Fix submodule URLs
-        run: |
-          git config --file .gitmodules submodule.avdecc-lib.url https://github.com/AVnu/avdecc-lib.git
-          git config --file .gitmodules submodule.lib/atl_avb.url https://github.com/zarfld/atl_avb.git
-          git config --file .gitmodules submodule.lib/igb_avb.url https://github.com/AVnu/igb_avb.git
-          git config --file .gitmodules submodule.thirdparty/cpputest.url https://github.com/cpputest/cpputest.git
-          git submodule sync
-          git submodule update --init --recursive
           
       - name: Run legacy make tasks
         run: |


### PR DESCRIPTION
## Summary
- checkout submodules recursively in GitHub Actions
- remove manual overrides of submodule URLs
- verify cpputest submodule during CI

## Testing
- `bash travis.sh` *(fails: CppUTestTests.OutOfMemoryTestsForOperatorNew)*

------
https://chatgpt.com/codex/tasks/task_e_6857bab33a4c8322836a45ac6c4e4e19