### PR TITLE
Switch Windows CI to Npcap SDK

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,0 +1,36 @@
+name: Windows Build
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - open-avb-next
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      WPCAP_DIR: ${{ github.workspace }}\npcap-sdk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download Npcap SDK
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Uri https://npcap.com/dist/npcap-sdk.zip -OutFile npcap-sdk.zip
+          Expand-Archive npcap-sdk.zip -DestinationPath npcap-sdk
+
+      - name: Set up CMake
+        uses: lukka/get-cmake@v3
+
+      - name: Configure
+        run: cmake -S . -B build -G "Visual Studio 17 2022"
+
+      - name: Build
+        run: cmake --build build --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ clone_depth: 20
 
 environment:
   # Config for mrp Windows build
-  WPCAP_DIR: c:\oavb\WpdPack
+  WPCAP_DIR: c:\oavb\npcap-sdk
   
 install:
   - git submodule update --init --recursive
-  # download WinPcap developer module and unzip it
-  - ps: Start-FileDownload 'https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip'
-  - ps: 7z x WpdPack_4_1_2.zip
+  # download Npcap developer pack and unzip it
+  - ps: Start-FileDownload 'https://npcap.com/dist/npcap-sdk.zip'
+  - ps: 7z x npcap-sdk.zip
 
 before_build:
   # cmake


### PR DESCRIPTION
## Summary
- use the Npcap developer pack rather than the obsolete WinPcap package
- create a Windows build workflow using the Npcap SDK

## Testing
- `make -n`

------
https://chatgpt.com/codex/tasks/task_e_6857befeff908322bcf38b4e332da63f