### PR TITLE
Fix ETH_ALEN for Windows

### DIFF
--- a/daemons/maap/common/platform.h
+++ b/daemons/maap/common/platform.h
@@ -47,9 +47,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define OS_TIME_TYPE struct timeval
 
+
 #elif defined(_WIN32)
 
 #include <Winsock2.h>
+
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
 
 #define htobe16(x) htons(x)
 #define be16toh(x) ntohs(x)


### PR DESCRIPTION
## Summary
- ensure `ETH_ALEN` is defined in the Windows section of `platform.h`

## Testing
- `make -s daemons_all`

------
https://chatgpt.com/codex/tasks/task_e_68591095d75c832287dc1635358dc363