### PR TITLE
Fix packet error printing

### DIFF
--- a/daemons/mrpd/mrpw.c
+++ b/daemons/mrpd/mrpw.c
@@ -297,11 +297,11 @@ int netif_capture_frame(struct netif *net_if, uint8_t ** frame,
 int netif_send_frame(struct netif *net_if, uint8_t * frame, uint16_t length)
 {
 	//printf("TX frame: %d bytes\n", length);
-	if (pcap_sendpacket(net_if->pcap_interface, frame, length) != 0) {
-		fprintf(stderr, "\nError sending the packet: \n",
-			pcap_geterr(net_if->pcap_interface));
-		return -1;
-	}
+       if (pcap_sendpacket(net_if->pcap_interface, frame, length) != 0) {
+               fprintf(stderr, "\nError sending the packet: %s\n",
+                       pcap_geterr(net_if->pcap_interface));
+               return -1;
+       }
 	return (0);
 }
 
@@ -608,11 +608,11 @@ int mrpd_close_socket(SOCKET sock)
 
 size_t mrpd_send(SOCKET sockfd, const void *buf, size_t len, int flags)
 {
-	if (pcap_sendpacket(net_if->pcap_interface, buf, len) != 0) {
-		fprintf(stderr, "\nError sending the packet: \n",
-			pcap_geterr(net_if->pcap_interface));
-		return -1;
-	}
+       if (pcap_sendpacket(net_if->pcap_interface, buf, len) != 0) {
+               fprintf(stderr, "\nError sending the packet: %s\n",
+                       pcap_geterr(net_if->pcap_interface));
+               return -1;
+       }
 	return len;
 }
 


### PR DESCRIPTION
## Summary
- fix packet send error message to include pcap error string

## Testing
- `make` in `daemons/mrpd`

------
https://chatgpt.com/codex/tasks/task_e_6859126725488322b8590a003c2602f7