### PR TITLE
Fix strlen size warnings in tests

### DIFF
--- a/daemons/mrpd/tests/simple/msrp_tests.cpp
+++ b/daemons/mrpd/tests/simple/msrp_tests.cpp
@@ -358,7 +358,7 @@ TEST(MsrpTestGroup, TxLVA_TalkerFailed_clear_tx_flag)
 		",B=" BRIDGE_ID ",C=" FAILURE_CODE;
 
 	/* declare single TalkerFailed */
-	msrp_recv_cmd(cmd_string, strlen(cmd_string) + 1, &client);
+        msrp_recv_cmd(cmd_string, (int)strlen(cmd_string) + 1, &client);
 	CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
 
 	/*
@@ -475,7 +475,7 @@ TEST(MsrpTestGroup, TxLVA_TalkerAdv_count_64)
 			"S++:S=%" PRIx64 ",A=%" PRIx64 ",V=" VLAN_ID ",Z=" TSPEC_MAX_FRAME_SIZE
 			",I=" TSPEC_MAX_FRAME_INTERVAL ",P=" PRIORITY_AND_RANK ",L=" ACCUMULATED_LATENCY,
 			id, da);
-		msrp_recv_cmd(cmd_string, strlen(cmd_string) + 1, &client);
+                msrp_recv_cmd(cmd_string, (int)strlen(cmd_string) + 1, &client);
 		CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
 		/* add 2 to prevent vectorizing */
 		id += 2;
@@ -509,11 +509,11 @@ TEST(MsrpTestGroup, Multiple_Clients)
 	memset(&client2, 1, sizeof(client2));
 
 	/* no error returned for first client */
-	msrp_recv_cmd("S??", strlen("S??") + 1, &client1);
+        msrp_recv_cmd("S??", (int)strlen("S??") + 1, &client1);
 	CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
 
 	/* no error returned for second client */
-	msrp_recv_cmd("S??", strlen("S??") + 1, &client2);
+        msrp_recv_cmd("S??", (int)strlen("S??") + 1, &client2);
 	CHECK(msrp_tests_cmd_ok(test_state.ctl_msg_data));
 }
 
@@ -527,12 +527,12 @@ TEST(MsrpTestGroup, Pruning_Commands_Fail)
 	int tx_flag_count = 0;
 
 	snprintf(cmd_string, sizeof(cmd_string), "I+S:S=%" PRIx64, id);
-	msrp_recv_cmd(cmd_string, strlen(cmd_string) + 1, &client);
+        msrp_recv_cmd(cmd_string, (int)strlen(cmd_string) + 1, &client);
 	CHECK(!msrp_tests_cmd_ok(test_state.ctl_msg_data));
 	LONGS_EQUAL(0, msrp_interesting_id_count());
 
 	snprintf(cmd_string, sizeof(cmd_string), "I-S:S=%" PRIx64, id);
-	msrp_recv_cmd(cmd_string, strlen(cmd_string) + 1, &client);
+        msrp_recv_cmd(cmd_string, (int)strlen(cmd_string) + 1, &client);
 	CHECK(!msrp_tests_cmd_ok(test_state.ctl_msg_data));
 	LONGS_EQUAL(0, msrp_interesting_id_count());
 }

--- a/daemons/mrpd/tests/simple/mvrp_pdu_tests.cpp
+++ b/daemons/mrpd/tests/simple/mvrp_pdu_tests.cpp
@@ -136,7 +136,7 @@ TEST(MvrpPDUTests, ParsePkt1)
 	memset(&client1, 0, sizeof(client1));
 
 	/* no error returned for first client */
-	mvrp_recv_cmd("V??", strlen("V??") + 1, &client1);
+        mvrp_recv_cmd("V??", (int)strlen("V??") + 1, &client1);
 	CHECK(mvrp_tests_cmd_ok(test_state.ctl_msg_data));
 	/* one client notification sent in response to V?? */
 	LONGS_EQUAL(1, test_state.sent_ctl_msg_count);

--- a/daemons/mrpd/tests/simple/parse_tests.cpp
+++ b/daemons/mrpd/tests/simple/parse_tests.cpp
@@ -76,7 +76,7 @@ TEST(ParseTestGroup, TestParse_null)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specs, &err_index);
+	status = parse(strz, (int)strlen(strz), specs, &err_index);
 	CHECK(0 != status);
 
 	// parse null is an error
@@ -105,14 +105,14 @@ TEST(ParseTestGroup, TestParse_u8)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specs, &err_index);
+	status = parse(strz, (int)strlen(strz), specs, &err_index);
 	CHECK(0 != status);
 
 	// zero case
 	ref = 0;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 
@@ -122,7 +122,7 @@ TEST(ParseTestGroup, TestParse_u8)
 		ref = (uint8_t)(1 << i);
 		sprintf(strz, "C=%u", ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specs, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 	}
@@ -131,7 +131,7 @@ TEST(ParseTestGroup, TestParse_u8)
 	ref = 0xff;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 
@@ -156,14 +156,14 @@ TEST(ParseTestGroup, TestParse_u16)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specs, &err_index);
+	status = parse(strz, (int)strlen(strz), specs, &err_index);
 	CHECK(0 != status);
 
 	// zero case
 	ref = 0;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 
@@ -173,7 +173,7 @@ TEST(ParseTestGroup, TestParse_u16)
 		ref = (uint16_t)(1 << i);
 		sprintf(strz, "C=%u", ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specs, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 	}
@@ -182,7 +182,7 @@ TEST(ParseTestGroup, TestParse_u16)
 	ref = 0xffff;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 }
@@ -206,14 +206,14 @@ TEST(ParseTestGroup, TestParse_u16_04x)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specs, &err_index);
+	status = parse(strz, (int)strlen(strz), specs, &err_index);
 	CHECK(0 != status);
 
 	// zero
 	ref = 0;
 	sprintf(strz, "C=%04x", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 
@@ -223,7 +223,7 @@ TEST(ParseTestGroup, TestParse_u16_04x)
 		ref = (uint16_t)(1 << i);
 		sprintf(strz, "C=%04x", ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specs, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 	}
@@ -232,7 +232,7 @@ TEST(ParseTestGroup, TestParse_u16_04x)
 	ref = 0xffff;
 	sprintf(strz, "C=%04x", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 }
@@ -256,14 +256,14 @@ TEST(ParseTestGroup, TestParse_u32)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specs, &err_index);
+	status = parse(strz, (int)strlen(strz), specs, &err_index);
 	CHECK(0 != status);
 
 	// 0 case
 	ref = 0;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 
@@ -273,7 +273,7 @@ TEST(ParseTestGroup, TestParse_u32)
 		ref = (uint32_t)1 << i;
 		sprintf(strz, "C=%u", ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specs, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 	}
@@ -282,7 +282,7 @@ TEST(ParseTestGroup, TestParse_u32)
 	ref = 0xffffffff;
 	sprintf(strz, "C=%u", ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specs, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specs, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 }
@@ -313,24 +313,24 @@ TEST(ParseTestGroup, TestParse_u64)
 
 	// error case where strlen() is used instead of sizeof()
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz), specsu, &err_index);
+	status = parse(strz, (int)strlen(strz), specsu, &err_index);
 	CHECK(0 != status);
 
 	// 0 case
 	ref = 0;
 	sprintf(strz, "C=%" SCNu64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsu, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsu, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 	sprintf(strz, "C=%" SCNx64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsx, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsx, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 	sprintf(strz, "C=%" SCNx64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsc, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsc, &err_index);
 	CHECK(0 == status);
 	for (j = 0; j < 8; j++)
 	{
@@ -343,17 +343,17 @@ TEST(ParseTestGroup, TestParse_u64)
 		ref = (uint64_t)1 << i;
 		sprintf(strz, "C=%" SCNu64, ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specsu, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specsu, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 		sprintf(strz, "C=%" SCNx64, ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specsx, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specsx, &err_index);
 		CHECK(0 == status);
 		CHECK(value == ref);
 		sprintf(strz, "C=%" SCNx64, ref);
 		memset(&value, 0, sizeof(value));
-		status = parse(strz, strlen(strz) + 1, specsc, &err_index);
+		status = parse(strz, (int)strlen(strz) + 1, specsc, &err_index);
 		CHECK(0 == status);
 		for (j = 0; j < 8; j++)
 		{
@@ -365,17 +365,17 @@ TEST(ParseTestGroup, TestParse_u64)
 	ref = (uint64_t)-1;
 	sprintf(strz, "C=%" SCNu64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsu, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsu, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 	sprintf(strz, "C=%" SCNx64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsx, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsx, &err_index);
 	CHECK(0 == status);
 	CHECK(value == ref);
 	sprintf(strz, "C=%" SCNx64, ref);
 	memset(&value, 0, sizeof(value));
-	status = parse(strz, strlen(strz) + 1, specsc, &err_index);
+	status = parse(strz, (int)strlen(strz) + 1, specsc, &err_index);
 	CHECK(0 == status);
 	for (j = 0; j < 8; j++)
 	{


### PR DESCRIPTION
## Summary
- cast strlen results when calling msrp_recv_cmd, mvrp_recv_cmd, and parse
- rebuild tests

## Testing
- `cmake .. -G "Unix Makefiles"`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: CppUTestTests.OutOfMemoryTestsForOperatorNew)*

------
https://chatgpt.com/codex/tasks/task_e_6859159e353c8322be6090c48ae89030