### PR TITLE
Fix winsock include order on Windows

### DIFF
--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_maap.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_maap.c
@@ -31,9 +31,9 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include <stdlib.h>
 #include <string.h>
-#include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <windows.h>
 
 #include "openavb_platform.h"
 #include "openavb_trace.h"

--- a/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_shaper.c
+++ b/lib/avtp_pipeline/platform/Windows/endpoint/openavb_endpoint_osal_shaper.c
@@ -31,9 +31,9 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include <stdlib.h>
 #include <string.h>
-#include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <windows.h>
 
 #include "openavb_platform.h"
 #include "openavb_trace.h"

--- a/lib/avtp_pipeline/platform/Windows/openavb_os_services_osal.h
+++ b/lib/avtp_pipeline/platform/Windows/openavb_os_services_osal.h
@@ -34,9 +34,9 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include "openavb_hal.h"
 
-#include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <windows.h>
 #include <process.h>
 #include <time.h>
 #include <errno.h>

--- a/lib/avtp_pipeline/platform/Windows/openavb_osal.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_osal.c
@@ -29,8 +29,8 @@ Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 
 #include "openavb_platform.h"
 #include "openavb_osal.h"

--- a/lib/avtp_pipeline/platform/Windows/openavb_osal_avdecc.c
+++ b/lib/avtp_pipeline/platform/Windows/openavb_osal_avdecc.c
@@ -29,8 +29,8 @@ Complete license and copyright information can be found at
 https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 *************************************************************************************************************/
 
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 
 #include "openavb_platform.h"
 #include "openavb_osal.h"


### PR DESCRIPTION
## Summary
- include `winsock2.h` before `windows.h` across Windows sources

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: `CppUTest/TestHarness.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68591aa1841c83229bcaa538e11c113a