### PR TITLE
Fix Windows OSAL struct definition

### DIFF
--- a/lib/avtp_pipeline/platform/Windows/openavb_os_services_osal_pub.h
+++ b/lib/avtp_pipeline/platform/Windows/openavb_os_services_osal_pub.h
@@ -63,6 +63,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 typedef struct {
         unsigned char buffer[6];
         unsigned char *mac;
+} cfg_mac_t;
 
 #define MUTEX_ATTR_TYPE_DEFAULT                                    0
 #define MUTEX_ATTR_TYPE_RECURSIVE                                  0


### PR DESCRIPTION
## Summary
- fix struct termination in `openavb_os_services_osal_pub.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859241d01e083229f61536129c7f598