### PR TITLE
Fix Windows OSAL header issues

### DIFF
--- a/lib/avtp_pipeline/include/openavb_types.h
+++ b/lib/avtp_pipeline/include/openavb_types.h
@@ -38,6 +38,10 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 
 #include "openavb_platform.h"
 
+#ifndef ETH_ALEN
+#define ETH_ALEN 6
+#endif
+
 typedef struct { // per IEEE 802.1Q-2011 Section 35.2.2.8.2
 	U8		addr[ETH_ALEN];
 	U16		uniqueID;

--- a/lib/avtp_pipeline/platform/Windows/openavb_time_osal_pub.h
+++ b/lib/avtp_pipeline/platform/Windows/openavb_time_osal_pub.h
@@ -40,7 +40,7 @@ https://github.com/benhoyt/inih/commit/74d2ca064fb293bc60a77b0bd068075b293cf175.
 #define AVB_TIME_CLOSE() osalAVBTimeClose()
 
 #define TIMERFD_CREATE(arg1, arg2) CreateWaitableTimer(NULL, TRUE, NULL)
-#define TIMERFD_SETTIME(arg1, arg2, arg3, arg4) \ 
+#define TIMERFD_SETTIME(arg1, arg2, arg3, arg4) \
         do { LARGE_INTEGER li; li.QuadPart = -((LONGLONG)((arg3)->it_value.tv_sec * 10000000LL + (arg3)->it_value.tv_nsec / 100)); \
              SetWaitableTimer(arg1, &li, 0, NULL, NULL, FALSE); } while (0)
 #define TIMER_CLOSE(arg1) CloseHandle(arg1)


### PR DESCRIPTION
## Summary
- fix macro line continuations in Windows time OSAL header
- define `ETH_ALEN` in `openavb_types.h` when missing

## Testing
- `make daemons_all`
- `make lib`

------
https://chatgpt.com/codex/tasks/task_e_685929576c408322a8357152eed48e3c