### PR TITLE
Fix inet_addr deprecation warning on Windows

### DIFF
--- a/daemons/mrpd/mrpw.c
+++ b/daemons/mrpd/mrpw.c
@@ -40,6 +40,7 @@
 
 #include <pcap.h>
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #include <iphlpapi.h>
 
 #include "mrpd.h"
@@ -645,10 +646,11 @@ int init_local_ctl(void)
 	if (iResult != NO_ERROR)
 		goto out;
 
-	memset(&addr, 0, sizeof(addr));
-	addr.sin_family = AF_INET;
-	addr.sin_port = htons(mrpd_port);
-	addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(mrpd_port);
+        if (inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr) != 1)
+                goto out;
 
 	rc = bind(sock_fd, (struct sockaddr *)&addr, sizeof(addr));
 


### PR DESCRIPTION
## Summary
- update Windows MRP build to use `inet_pton`
- include `ws2tcpip.h` for the replacement API

## Testing
- `make -C daemons/mrpd mrpd`
- `./travis.sh` *(fails: CppUTestTests.OutOfMemoryTestsForOperatorNew)*

------
https://chatgpt.com/codex/tasks/task_e_685936696e888322a726e82cff88d066