### PR TITLE
Fix profile framework link when pipeline absent

### DIFF
--- a/lib/avtp_pipeline/profile/CMakeLists.txt
+++ b/lib/avtp_pipeline/profile/CMakeLists.txt
@@ -46,8 +46,8 @@ install(TARGETS openavb_profile_framework
 )
 
 # Add to main OpenAvnu build
-if(NOT TARGET openavb_avtp_pipeline)
+if(TARGET openavb_avtp_pipeline)
+    target_link_libraries(openavb_avtp_pipeline openavb_profile_framework)
+else()
     message(WARNING "Profile framework requires openavb_avtp_pipeline target")
 endif()
-
-target_link_libraries(openavb_avtp_pipeline openavb_profile_framework)


### PR DESCRIPTION
## Summary
- update profile CMakeLists.txt to link `openavb_profile_framework` only if
  the `openavb_avtp_pipeline` target exists
- provide warning otherwise

## Testing
- `cmake -S lib/avtp_pipeline/profile -B build_profile`

------
https://chatgpt.com/codex/tasks/task_e_686c38d5aaa08322a1c151c51af56f65