### PR TITLE
Fix MAAP log message truncation

### DIFF
--- a/daemons/maap/linux/src/maap_log_linux.c
+++ b/daemons/maap/linux/src/maap_log_linux.c
@@ -307,7 +307,8 @@ void maapLogFn(
 				if (elem) {
 					log_queue_item_t *pLogItem = (log_queue_item_t *)maapLogQueueData(elem);
 					pLogItem->bRT = FALSE;
-					strncpy((char *)pLogItem->msg, full_msg, LOG_QUEUE_MSG_LEN);
+                                       strncpy((char *)pLogItem->msg, full_msg, LOG_QUEUE_MSG_LEN - 1);
+                                       pLogItem->msg[LOG_QUEUE_MSG_LEN - 1] = '\0';
 					maapLogQueueHeadPush(logQueue);
 				}
 			}

--- a/daemons/maap/windows/src/maap_log_windows.c
+++ b/daemons/maap/windows/src/maap_log_windows.c
@@ -289,7 +289,8 @@ void maapLogFn(
 				if (elem) {
 					log_queue_item_t *pLogItem = (log_queue_item_t *)maapLogQueueData(elem);
 					pLogItem->bRT = FALSE;
-					strncpy((char *)pLogItem->msg, full_msg, LOG_QUEUE_MSG_LEN);
+                                       strncpy((char *)pLogItem->msg, full_msg, LOG_QUEUE_MSG_LEN - 1);
+                                       pLogItem->msg[LOG_QUEUE_MSG_LEN - 1] = '\0';
 					maapLogQueueHeadPush(logQueue);
 				}
 			}


### PR DESCRIPTION
## Summary
- ensure Linux and Windows MAAP log buffers always end with NUL terminator
- rebuild MAAP Linux daemon to confirm there are no warnings

## Testing
- `make -C daemons/maap/linux/build`

------
https://chatgpt.com/codex/tasks/task_e_686c3a09b48883229c48b5af6834bae9